### PR TITLE
Update aircraft-meta.json

### DIFF
--- a/public/aircraft-meta.json
+++ b/public/aircraft-meta.json
@@ -1,3534 +1,10035 @@
 [
-    {
-	"key": "F-15 Eagle",
-	"altNames": ["F-15", "Eagle"], 
-	"tags": ["Plane", "Jet Plane", "Twin Engines", "Jet", "Fighter Jet", "Air Superiority", "Interceptor", "Air-to-Air", "Air-to-Ground", "Dual-Role Fighter", "Multi-Role Fighter", "High Maneuverability", "Supersonic", "All-Weather Fighter", "Long-Range", "Combat-Ready", "Heavy Fighter", "Tactical Fighter", "Modern Warfare", "BVR", "Stealth Countermeasure"],
-	"hltag": ["NCR"],
+  {
+	"key": "A-10 Thunderbolt II",
+	"altNames": ["A-10", "Thunderbolt II", "Thunderbolt"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":["Ground Attack", "Close Air Support", "Fighter Bomber"],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "McDonnell Douglas"
+              "key": "Manufacturer",
+              "value": "Fairchild Republic"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "F/A-18 Hornet, F-16 Fighting Falcon"
+              "key": "Similar Aircraft",
+              "value": "Su-25 Frogfoot, Su-17 Fitter, Q-5 Fantan"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Twin-engine, straight-wing design with a large 30mm GAU-8 Avenger cannon mounted in the nose."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "One"
           },
           {
-              "key": "Role:",
-              "value": "Air superiority fighter, capable of air-to-air and air-to-ground missions"
+              "key": "Role",
+              "value": "Close Air Support"
           },
           {
-              "key": "Armament:",
-              "value": "Air-to-air missiles (AIM-7, AIM-120, AIM-9), air-to-ground bombs and missiles, 20mm M61 Vulcan cannon"
+              "key": "Armament",
+              "value": "One 30mm GAU-8 Avenger cannon, up to 16,000 lbs of ordnance on 11 hardpoints (including missiles, bombs, rockets, and fuel tanks)"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 63 ft, 9 in (19.43 m), Span: 42 ft, 10 in (13.05 m)"
+              "key": "Dimensions",
+              "value": "Length: 16.26 meters (53 ft 4 in), Wingspan: 17.53 meters (57 ft 6 in), Height: 4.47 meters (14 ft 8 in)"
           },            
           {
-              "key": "Names:",
+              "key": "Names",
+              "value": "A-10 Thunder Bolt II, A-10, Thunderbolt II, Thunderbolt "
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Straight, low-mounted wings with large external hardpoints for carrying a wide variety of ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two high-mounted turbofan engines, located above and behind the wings, providing thrust and redundancy in case of engine failure."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Bulky and robust with a prominent bubble canopy and a thick, armored cockpit designed to protect the pilot."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers with a horizontal stabilizer connecting them, mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "SU-25 Frogfoot",
+	"altNames": ["SU-25", "Frogfoot"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":["Ground Attack", "Close Air Support", "Fighter Bomber"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Sukhoi"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "A-10 Thunderbolt II, Su-17 Fitter, Q-5 Fantan"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Armored cockpit, straight wings, and twin-engine design with engines mounted close to the fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Close Air Support / Ground Attack"
+          },
+          {
+              "key": "Armament",
+              "value": "One GSh-30-2 30mm cannon, up to 8,000 kg of ordnance on 10 hardpoints (including air-to-ground missiles, bombs, rockets, and gun pods)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 15.53 meters (50 ft 11 in), Wingspan: 14.36 meters (47 ft 1 in), Height: 4.80 meters (15 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "SU-25 Frogfoot, SU-25, Frogfoot"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Straight, low-mounted wings with multiple hardpoints for carrying various air-to-ground ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Twin turbofan engines mounted on the rear fuselage close to the body, providing thrust and redundancy."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Bulky, armored fuselage designed to protect the pilot and withstand ground fire. The cockpit is raised for improved visibility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers positioned wide apart, with a horizontal stabilizer connecting them."
+          }          
+      ]
+	},
+{
+	"key": "AMX",
+	"altNames": ["AMX International",  "International"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["Ground Attack", "Close Air Support", "Fighter Bomber"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Alenia, Embraer"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Italy/Brazil"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Jaguar"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Single-engine, high-mounted wings, and a distinctive large, bubble canopy."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Ground Attack / Fighter-Bomber"
+          },
+          {
+              "key": "Armament",
+              "value": "One 20mm M61 Vulcan cannon, up to 3,800 kg of ordnance on 5 hardpoints (including bombs, rockets, and air-to-ground missiles)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 13.23 meters (43 ft 5 in), Wingspan: 8.87 meters (29 ft 1 in), Height: 4.55 meters (14 ft 11 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "AMX, AMX International "
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted, slightly swept wings with hardpoints for carrying external ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted at the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact and streamlined fuselage with a raised bubble canopy for excellent pilot visibility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a T-tail configuration."
+          }          
+      ]
+	},
+{
+	"key": "AV-8 Harrier II",
+	"altNames": ["AV-8", "Harrier II", "Harrier"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["Ground Attack", "Close Air Support", "Fighter Bomber"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "McDonnell Douglas / British Aerospace"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States / United Kingdom"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "F-35B Lightning II"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Vertical/Short Takeoff and Landing (V/STOL) capability with large intake ducts on the sides."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Ground Attack / Close Air Support"
+          },
+          {
+              "key": "Armament",
+              "value": "One GAU-12 Equalizer 25mm cannon, up to 4,200 kg of ordnance on 7 hardpoints (including bombs, rockets, air-to-air and air-to-ground missiles)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 14.12 meters (46 ft 4 in), Wingspan: 9.25 meters (30 ft 4 in), Height: 3.55 meters (11 ft 8 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "AV-8 Harrier II, AV-8, Harrier II, Harrier"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Mid-mounted, slightly swept wings with hardpoints for external ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine with thrust-vectoring nozzles for V/STOL capability, mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Short and stubby with large air intakes on the sides for engine cooling."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "Sepecat Jaguar",
+	"altNames": ["Jaguar"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["Ground Attack", "Close Air Support", "Fighter Bomber"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "SEPECAT (A collaboration between Breguet and BAC)"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United Kingdom / France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "AMX, Mirage F1, "
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine, high-mounted wings, and a narrow fuselage with a distinctive bubble canopy."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Ground Attack / Fighter-Bomber"
+          },
+          {
+              "key": "Armament",
+              "value": "Two 30mm DEFA cannons, up to 4,500 kg of ordnance on 5 hardpoints (including bombs, rockets, and air-to-ground missiles)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 16.83 meters (55 ft 3 in), Wingspan: 8.69 meters (28 ft 6 in), Height: 4.89 meters (16 ft)"
+          },            
+          {
+              "key": "Names",
+              "value": "Sepecat Jaguar, Jaguar"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted, slightly swept wings with external hardpoints for ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and narrow, with a raised bubble canopy for improved visibility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "Q-5 Fantan ",
+	"altNames": ["Q-5", "Fantan "], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["Ground Attack", "Close Air Support", "Fighter Bomber"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Nanchang Aircraft Manufacturing Company"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "China"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MiG-19 Farmer, Su-7 Fitter"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine design, delta-wing configuration, and narrow fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Ground Attack"
+          },
+          {
+              "key": "Armament",
+              "value": "Two 23mm cannons, up to 2,000 kg of ordnance on 6 hardpoints (including bombs, rockets, and air-to-ground missiles)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 15.65 meters (51 ft 4 in), Wingspan: 9.68 meters (31 ft 9 in), Height: 4.33 meters (14 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Q-5 Fantan, Q-5, Fantan"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted, swept wings with external hardpoints for carrying ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Twin turbojet engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Narrow and streamlined fuselage with a pointed nose and bubble canopy."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "Su-24 Fencer",
+	"altNames": ["Su-24", "Fencer"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["Ground Attack", "Close Air Support", "Fighter Bomber"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Sukhoi"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Tornado IDS"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Variable-sweep wings, twin-engine design, and side-by-side seating in the cockpit."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Ground Attack / Fighter-Bomber"
+          },
+          {
+              "key": "Armament",
+              "value": "One GSh-6-23M 23mm cannon, up to 8,000 kg of ordnance on 8 hardpoints (including bombs, rockets, and air-to-ground missiles)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 22.67 meters (74 ft 5 in), Wingspan: 17.64 meters (57 ft 10 in), Height: 6.19 meters (20 ft 4 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Su-24 Fencer, Su-24, Fencer"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Variable-sweep wings that can be extended or swept back depending on the mission profile."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and bulky fuselage with a wide, boxy cockpit for side-by-side seating."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout and a horizontal stabilizer at the rear."
+          }          
+      ]
+	},
+{
+	"key": "Tornado IDS",
+	"altNames": ["Tornado"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["Ground Attack", "Close Air Support", "Fighter Bomber"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Panavia Aircraft GmbH"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United Kingdom / Germany / Italy"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Su-24 Fencer, MiG-27 Flogger"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Variable-sweep wings, twin-engine design, and a two-seat tandem cockpit."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Interdictor / Strike Aircraft"
+          },
+          {
+              "key": "Armament",
+              "value": "One 27mm Mauser BK-27 cannon, up to 9,000 kg of ordnance on 9 hardpoints (including bombs, rockets, air-to-ground missiles)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 16.72 meters (54 ft 10 in), Wingspan: 13.91 meters (45 ft 8 in), Height: 5.95 meters (19 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Tornado IDS, Tornado"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Variable-sweep wings that adjust according to speed and mission requirements."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact, with a narrow fuselage and tandem seating in the cockpit."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "A-37 Dragon Fly",
+	"altNames": ["A-37", "Dragon Fly"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["COIN", "Light Attack"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Cessna"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Embraer EMB 314 Super Tucano, Pilatus PC-9"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Lightweight attack aircraft with a high aspect ratio wing, designed for counter-insurgency and close air support."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Light Attack / COIN"
+          },
+          {
+              "key": "Armament",
+              "value": "Can carry rockets, bombs, and gun pods"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11.03 meters (36 ft 2 in), Wingspan: 10.82 meters (35 ft 6 in), Height: 3.42 meters (11 ft 3 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "A-37 Dragon Fly, A-37, Dragon Fly"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for stability and maneuverability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage designed for efficient performance in light attack roles."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "A-29 Super Tucano",
+	"altNames": ["A-29", "Super Tucano"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["COIN", "Light Attack"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Embraer"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Brazil"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Beechcraft AT-6 Texan II, A-37 Dragon Fly"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Turboprop light attack aircraft with a low-wing design and advanced avionics for COIN operations."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Light Attack / COIN"
+          },
+          {
+              "key": "Armament",
+              "value": "Can carry bombs, rockets, and machine guns"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": " Length: 12.7 meters (41 ft 8 in), Wingspan: 11.14 meters (36 ft 6 in), Height: 4.15 meters (13 ft 7 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "A-29 Super Tucano, A-29, Super Tucano"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for stability and payload capacity."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboprop engine mounted in the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slim fuselage with a spacious cabin for pilot and avionics."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Alpha Jet",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["Trainer", "Trainer-Combat", "Light Attack"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Dassault-Breguet / Dornier"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France / Germany"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "L-39 Albatross, T-38 Talon"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light attack and advanced trainer aircraft with a tandem seating configuration and low-wing design."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Trainer / Light Attack"
+          },
+          {
+              "key": "Armament",
+              "value": "Can carry bombs, rockets, and gun pods"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 12.20 meters (40 ft 0 in), Wingspan: 9.70 meters (31 ft 10 in), Height: 3.40 meters (11 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Alpha Jet"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings with a slight sweep for improved aerodynamics."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage designed for pilot training and light attack operations."
+          },     
+          {
+              "key": "Tail",
+              "value": "T-tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+
+{
+	"key": "SF-260W",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["Trainer", "Trainer-Combat", "Light Attack"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "SIAI-Marchetti"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Italy"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Embraer EMB 312 Tucano, Beechcraft T-34 Mentor"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light aircraft designed for primary and advanced flight training, featuring a low-wing configuration and good visibility."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Trainer / Light Attack"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be equipped with machine guns and light bombs"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 8.18 meters (26 ft 10 in), Wingspan: 10.52 meters (34 ft 6 in), Height: 2.46 meters (8 ft 1 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "SF-260W"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for stability and performance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single piston engine mounted in the nose."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage designed for training with a spacious cockpit."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "F-14 Tomcat",
+	"altNames": ["F-14", "Tomcat"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":["Air Superiority", "Interceptor", "Fighter Jet"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Grumman"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "F-15 Eagle, MiG-23 Flogger, Su-27 Flanker"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine design, variable-sweep wings, and distinctive twin tail fins."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Air Superiority / Interceptor"
+          },
+          {
+              "key": "Armament",
+              "value": "One 20mm M61 Vulcan cannon, up to 6,600 kg of ordnance on 10 hardpoints (including air-to-air missiles and bombs)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 19.13 meters (62 ft 9 in), Wingspan: 19.55 meters (64 ft 2 in) (with wings extended), Height: 4.88 meters (16 ft)"
+          },            
+          {
+              "key": "Names",
+              "value": "F-14 Tomcat, F-14, Tomcat"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Variable-sweep wings that adjust depending on the speed and mission."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and sleek fuselage with a raised canopy for tandem seating of pilot and radar intercept officer."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "F-15 Eagle",
+	"altNames": ["F-15, Eagle"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":["Air Superiority", "Interceptor", "Multirole Aircraft", "Fighter Jet"],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "McDonnell Douglas"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "F-14 Tomcat, Su-27 Flanker, MiG-29 Fulcrum"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine design with large, straight wings and twin vertical stabilizers."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Air Superiority Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "One 20mm M61 Vulcan cannon, up to 7,300 kg of ordnance on 11 hardpoints (including air-to-air missiles and bombs)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 19.44 meters (63 ft 9 in), Wingspan: 13.05 meters (42 ft 10 in), Height: 5.63 meters (18 ft 6 in)"
+          },            
+          {
+              "key": "Names",
               "value": "F-15 Eagle, F-15, Eagle"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Mid-mounted, swept-back wings with square tips and a slight dihedral."
+              "key": "Wings",
+              "value": "Large, straight wings with multiple hardpoints for carrying external ordnance."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines with afterburners, mounted internally at the rear of the fuselage, with visible nozzles extending beyond the fuselage."
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted at the rear fuselage."
           },
           {
-              "key": "Fuselage:",
-              "value": "Long and sleek with a pointed nose. The cockpit is located forward of the wings, providing the pilot with excellent visibility. The fuselage has a distinctive wedge-shaped design, with twin intakes under the wings for engine air supply."
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a bubble canopy providing excellent visibility."
           },     
           {
-              "key": "Tail:",
-              "value": "Twin vertical stabilizers mounted outward on either side of the engine exhausts, with low-mounted horizontal stabilizers. The twin-tail configuration enhances maneuverability and control, contributing to the aircraft’s air superiority role. “Shark Tooth” on stabilizer."
+              "key": "Tail",
+              "value": "Twin vertical stabilizers mounted at the rear of the fuselage."
           }          
       ]
 	},
-    {
+{
 	"key": "F-16 Fighting Falcon",
-	"altNames": ["F-16", "Fighting Falcon"], 
-	"tags": ["Plane", "Jet Plane", "Single Engine", "Jet", "Fighter Jet", "Air Superiority", "Interceptor", "Air-to-Air", "Air-to-Ground", "Dual-Role Fighter", "Multi-Role Fighter", "High Maneuverability", "Supersonic", "All-Weather Fighter", "Light Fighter", "Tactical Fighter", "BVR", "Combat-Ready", "Aerobatics", "Modern Warfare"],
-	"hltag": ["NCR"],
+	"altNames": ["F-16, Fighting Falcon"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":["Air Superiority", "Interceptor", "Multirole Aircraft", "Fighter Jet"],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "General Dyamics"
+              "key": "Manufacturer",
+              "value": "General Dynamics"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "F/A-18 Hornet, F-15 Eagle"
+              "key": "Similar Aircraft",
+              "value": "F/A-18 Hornet, JF-17 Thunder, MiG-29 Fulcrum"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Single-engine, bubble canopy, and blended wing-body design."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "One"
           },
           {
-              "key": "Role:",
-              "value": "Multi-role fighter jet for air-to-air combat and air-to-ground attack missions"
+              "key": "Role",
+              "value": "Multirole Fighter"
           },
           {
-              "key": "Armament:",
-              "value": "Air-to-air missiles (AIM-9, AIM-120), air-to-ground bombs (GBU, JDAM), 20mm M61 Vulcan cannon"
+              "key": "Armament",
+              "value": "One 20mm M61 Vulcan cannon, up to 7,700 kg of ordnance on 9 hardpoints (including air-to-air missiles, bombs, and fuel tanks)"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 49 ft, 5 in (15.06 m), Span: 32 ft, 8 in (9.96 m)"
+              "key": "Dimensions",
+              "value": "Length: 15.06 meters (49 ft 5 in), Wingspan: 9.96 meters (32 ft 8 in), Height: 4.88 meters (16 ft)"
           },            
           {
-              "key": "Names:",
+              "key": "Names",
               "value": "F-16 Fighting Falcon, F-16, Fighting Falcon"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Mid-mounted, swept-back wings with sharp leading edges and clipped tips, providing excellent maneuverability at high speeds."
+              "key": "Wings",
+              "value": "Mid-mounted, cropped-delta wings with multiple hardpoints for external ordnance."
           },
           {
-              "key": "Engine(s):",
-              "value": "Single turbofan engine with afterburner mounted inside the fuselage, with an exhaust nozzle extending slightly beyond the rear."
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted in the rear fuselage."
           },
           {
-              "key": "Fuselage:",
-              "value": "Sleek, aerodynamically optimized fuselage with a bubble canopy for enhanced pilot visibility. The nose is sharp and pointed, housing advanced radar systems. The body tapers towards the tail, providing a streamlined appearance."
+              "key": "Fuselage",
+              "value": "Blended wing-body design with a streamlined fuselage and a large bubble canopy."
           },     
           {
-              "key": "Tail:",
-              "value": "Single vertical stabilizer with twin low-mounted horizontal stabilizers. The vertical stabilizer is large and canted slightly backwards, while the horizontal stabilizers are broad and positioned towards the rear of the fuselage."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
           }          
       ]
 	},
-    {
+{
 	"key": "F/A-18 Hornet",
-	"altNames": ["F-18 Hornet", "F/A-18", "F-18, Hornet"], 
-	"tags": ["Plane", "Jet Plane", "Twin Engines", "Jet", "Fighter Jet", "Air Superiority", "Interceptor", "Air-to-Air", "Air-to-Ground", "Dual-Role Fighter", "Multi-Role Fighter", "High Maneuverability", "Supersonic", "Carrier-Based", "All-Weather Fighter", "Tactical Fighter", "BVR", "Combat-Ready", "Aerobatics", "Modern Warfare"],
+	"altNames": ["F/A-18", "Hornet", "F-18 Hornet", "F-18"], 
+	"tags": [],
 	"hltag": ["NCR"],
+	"accat":["Air Superiority", "Strike Attack", "Multirole Aircraft", "Fighter Jet"],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "McDonnell Douglas"
+              "key": "Manufacturer",
+              "value": "McDonnell Douglas / Northrop"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "F-16 Fighting Falcon, F-15 Eagle"
+              "key": "Similar Aircraft",
+              "value": "F-16 Fighting Falcon, MiG-29 Fulcrum, JAS 39 Gripen"
               
           },
           {
-              "key": "Crew:",
-              "value": "One (pilot) or two (pilot and weapons systems officer, depending on variant)"
+              "key": "Distinctive Features",
+              "value": "Twin-engine, canted twin tail fins, and leading-edge extensions on the wings."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One (F/A-18A/C) or Two (F/A-18B/D)"
           },
           {
-              "key": "Role:",
-              "value": "Multi-role fighter jet for air-to-air combat and air-to-ground attack missions"
+              "key": "Role",
+              "value": "Multirole Fighter / Strike Aircraft"
           },
           {
-              "key": "Armament:",
-              "value": "Air-to-air missiles (AIM-9, AIM-120), air-to-ground bombs and missiles (GBU, JDAM), 20mm M61 Vulcan cannon"
+              "key": "Armament",
+              "value": "One 20mm M61 Vulcan cannon, up to 6,200 kg of ordnance on 9 hardpoints (including air-to-air missiles, bombs, and fuel tanks)"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 56 ft (17.1 m), Span: 40 ft, 4 in (12.3 m)"
+              "key": "Dimensions",
+              "value": "Length: 17.07 meters (56 ft), Wingspan: 12.31 meters (40 ft 5 in), Height: 4.66 meters (15 ft 3 in)"
           },            
           {
-              "key": "Names:",
-              "value": "F/A-18 Hornet, F-18 Hornet, F/A-18, F-18, Hornet"
+              "key": "Names",
+              "value": "F/A-18 Hornet, F/A-18, Hornet, F-18 Hornet, F-18"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Mid-mounted, swept-back wings with square tips and outward-angled leading edges. The wings are equipped with leading-edge extensions (LEX) that improve maneuverability and stability during high-angle-of-attack maneuvers."
+              "key": "Wings",
+              "value": "Mid-mounted, swept-back wings with leading-edge extensions and multiple hardpoints for ordnance."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines with afterburners mounted internally at the rear of the fuselage, with twin exhaust nozzles extending slightly beyond the fuselage."
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted in the rear fuselage."
           },
           {
-              "key": "Fuselage:",
-              "value": "Sleek and aerodynamic with a pointed nose, housing radar and avionics. The cockpit is positioned forward of the wings and features a bubble canopy for excellent pilot visibility. The fuselage tapers toward the rear, providing a streamlined design for high-speed performance."
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a bubble canopy and prominent wing-body blending."
           },     
           {
-              "key": "Tail:",
-              "value": "Twin vertical stabilizers mounted outward on either side of the exhausts, with two low-mounted horizontal stabilizers. The twin-tail configuration offers enhanced control and stability during air combat maneuvers."
-          }         
+              "key": "Tail",
+              "value": "Twin vertical stabilizers canted outward at the rear of the fuselage."
+          }          
       ]
 	},
-    {
+{
 	"key": "F-22 Raptor",
-	"altNames": ["F-22, Raptor"], 
-	"tags": ["Plane", "Jet Plane", "Twin Engines", "Jet", "Fighter Jet", "Air Superiority", "Stealth", "Interceptor", "Air-to-Air", "Air-to-Ground", "Multi-Role Fighter", "Supersonic", "High Maneuverability", "BVR", "5th Generation Fighter", "Stealth Fighter", "Modern Warfare"],
+	"altNames": ["F-22", "Raptor"], 
+	"tags": [],
 	"hltag": ["NCR"],
+	"accat":["Air Superiority", "Interceptor", "Multirole Aircraft", "Fighter Jet", "Steath", "Steath Fighter" ],
 	"generalData": [
           {
-              "key": "Manufacturer:",
+              "key": "Manufacturer",
               "value": "Lockheed Martin"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "F-35 Lightning II, F-15 Eagle"   
+              "key": "Similar Aircraft",
+              "value": "F-35 Lightning II, Su-57 Felon"
+              
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Stealth design, twin-engine, internal weapons bays, and thrust-vectoring nozzles."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "One"
           },
           {
-              "key": "Role:",
-              "value": "Air superiority stealth fighter with advanced air-to-air and air-to-ground capabilities"
+              "key": "Role",
+              "value": "Air Superiority Fighter"
           },
           {
-              "key": "Armament:",
-              "value": "Air-to-air missiles (AIM-9, AIM-120), air-to-ground bombs (JDAM, SDB), 20mm M61 Vulcan cannon"
+              "key": "Armament",
+              "value": "One 20mm M61 Vulcan cannon, up to 8,200 kg of ordnance in internal bays (including air-to-air missiles and bombs)"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 62 ft, 1 in (18.9 m), Span: 44 ft, 6 in (13.6 m)"
+              "key": "Dimensions",
+              "value": "Length: 18.90 meters (62 ft), Wingspan: 13.56 meters (44 ft 6 in), Height: 5.08 meters (16 ft 8 in)"
           },            
           {
-              "key": "Names:",
+              "key": "Names",
               "value": "F-22 Raptor, F-22, Raptor"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Mid-mounted trapezoidal wings with sharp, clipped tips and minimal dihedral. The wings are designed for stealth and high maneuverability at high speeds."
+              "key": "Wings",
+              "value": "Mid-mounted, trapezoidal wings designed for stealth and maneuverability."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines with afterburners and thrust vectoring nozzles, mounted internally at the rear of the fuselage. The exhaust nozzles are flat and wide, contributing to the stealth profile."
+              "key": "Engine(s)",
+              "value": "Two turbofan engines with thrust-vectoring nozzles mounted in the rear fuselage."
           },
           {
-              "key": "Fuselage:",
-              "value": "Sleek, angular fuselage with a pointed nose and blended body contours designed for low radar visibility. The cockpit is located forward of the wings and features a bubble canopy that provides excellent visibility. The overall shape of the fuselage is optimized for stealth, with internal weapons bays to reduce radar signature."
+              "key": "Fuselage",
+              "value": "Sleek, angular fuselage with internal weapons bays for stealth."
           },     
           {
-              "key": "Tail:",
-              "value": "Twin vertical stabilizers that are canted outward, along with large horizontal stabilizers positioned near the tail, contributing to the aircraft's agility and control during high-speed maneuvers."
+              "key": "Tail",
+              "value": "Twin vertical stabilizers canted outward and thrust-vectoring nozzles at the rear of the fuselage."
           }          
       ]
 	},
-    {
-	"key": "AN-124 Condor",
-	"altNames": ["AN-124", "Condor"], 
-	"tags": ["Plane", "Cargo Plane", "Heavy-Lift", "Transport Aircraft", "Strategic Airlift", "Four Engines", "Long Range", "Military Transport", "Oversized Cargo", "Wide-body", "Tactical Airlift", "Heavy Cargo"],
-	"hltag": ["NCR"],
+{
+	"key": "F-35 Lightning II",
+	"altNames": ["F-35", "Lightning II", "Lighting"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":["Air Superiority", "Interceptor", "Multirole Aircraft", "Fighter Jet", "Steath", "Steath Fighter"],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Antonov"
+              "key": "Manufacturer",
+              "value": "Lockheed Martin"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "Russia"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "C-5 Galaxy, C-17 Globemaster III, C-130 Hercules"
+              "key": "Similar Aircraft",
+              "value": ": F-22 Raptor, J-20 Mighty Dragon, Su-57 Felon"
+              
           },
           {
-              "key": "Crew:",
-              "value": "Six"
+              "key": "Distinctive Features",
+              "value": "Stealth design, single-engine, internal weapons bays, and advanced avionics."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
           },
           {
-              "key": "Role:",
-              "value": "Strategic heavy-lift cargo aircraft for transporting oversized equipment, vehicles, and cargo"
+              "key": "Role",
+              "value": "Multirole Stealth Fighter"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "One 25mm GAU-22/A cannon (F-35A), up to 8,160 kg of ordnance in internal bays and on external hardpoints (including air-to-air missiles and bombs)"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 226 ft, 9 in (69.1 m), Span: 240 ft, 5 in (73.3 m)"
+              "key": "Dimensions",
+              "value": "Length: 15.67 meters (51 ft 5 in), Wingspan: 10.67 meters (35 ft), Height: 4.33 meters (14 ft 2 in)"
           },            
           {
-              "key": "Names:",
-              "value": "AN-124 Condor, AN-124, Condor"
+              "key": "Names",
+              "value": "F-35 Lightning II, F-35, Lightning II, Lighting"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "High-mounted, swept-back wings with slight taper and broad, square tips."
+              "key": "Wings",
+              "value": "Low-mounted, swept wings designed for stealth and agility, with internal and external hardpoints for ordnance."
           },
           {
-              "key": "Engine(s):",
-              "value": "Four turbofan engines mounted under the wings, with large nacelles extending forward of the wings' leading edges."
+              "key": "Engine(s)",
+              "value": "Single turbofan engine with a rear exhaust nozzle, designed for stealth and supersonic performance."
           },
           {
-              "key": "Fuselage:",
-              "value": "Extremely large and wide fuselage with a rounded nose, which opens upwards for cargo loading. The fuselage is designed to carry oversized cargo and has a double-deck structure with the cockpit and crew positioned in the upper section."
+              "key": "Fuselage",
+              "value": "Sleek and angular with an internal weapons bay to reduce radar cross-section."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail with a low-mounted horizontal stabilizer "
+              "key": "Tail",
+              "value": "Twin vertical stabilizers canted outward, mounted toward the rear of the fuselage."
           }          
       ]
 	},
-    {
-	"key": "C-5 Galaxy",
-	"altNames": ["C-5", "Galaxy"],
-	"tags": ["Plane", "Cargo Plane", "Heavy-Lift", "Transport Aircraft", "Strategic Airlift", "Four Engines", "Long Range", "Military Transport", "Oversized Cargo", "Wide-body", "Tactical Airlift", "Heavy Cargo", "High Capacity"],
-	"hltag": ["NCR"],
+{
+	"key": "J-10 Jian",
+	"altNames": ["J-10", "Jian"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Lockheed"
+              "key": "Manufacturer",
+              "value": "Chengdu Aircraft Corporation"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "China"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Aircraft: Antonov An-124, C-17 Globemaster III, C-130 Hercules"  
+              "key": "Similar Aircraft",
+              "value": "JF-17 Thunder, F-16 Fighting Falcon, MiG-29 Fulcrum"
+              
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Single-engine, delta-wing design with canards."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Multirole Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "One 23mm cannon, up to 6,000 kg of ordnance on 11 hardpoints (including air-to-air missiles, bombs, and fuel tanks)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 15.49 meters (50 ft 10 in), Wingspan: 9.75 meters (32 ft), Height: 5.43 meters (17 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "J-10 Jian, J-10, Jian 10"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Mid-mounted delta wings with large canards positioned near the cockpit for enhanced maneuverability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with an angular design and blended wing-body structure."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "JF-17 Thunder",
+	"altNames": ["JF-17", "Thunder"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Pakistan Aeronautical Complex (PAC) / Chengdu Aircraft Corporation"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Pakistan / China"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "F-16 Fighting Falcon, J-10 Jian-10, MiG-29 Fulcrum"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Single-engine, lightweight multirole fighter with a sharp nose and bubble canopy."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Multirole Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "One 23mm cannon, up to 3,600 kg of ordnance on 7 hardpoints (including air-to-air missiles, bombs, and fuel tanks)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 14.93 meters (49 ft), Wingspan: 9.45 meters (31 ft), Height: 4.77 meters (15 ft 8 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "JF-17 Thunder, JF-17, Thunder"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Mid-mounted, cropped-delta wings with hardpoints for external ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined and compact fuselage with a bubble canopy for good visibility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "MiG-29 Fulcrum",
+	"altNames": ["MiG-29", "Fulcrum"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mikoyan"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Su-27 Flanker, F-16 Fighting Falcon, F/A-18 Hornet"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine design with large air intakes under the fuselage, and twin vertical stabilizers."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Air Superiority Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "One 30mm GSh-30-1 cannon, up to 4,000 kg of ordnance on 7 hardpoints (including air-to-air missiles and bombs)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 17.32 meters (56 ft 10 in), Wingspan: 11.36 meters (37 ft 3 in), Height: 4.73 meters (15 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MiG-29 Fulcrum, MiG-29,Fulcrum"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Mid-mounted, swept-back wings with multiple hardpoints for external ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines with air intakes mounted underneath the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a raised cockpit and large air intakes beneath the body."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers mounted widely apart at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "Mirage 5",
+	"altNames": ["Mirage III"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Dassault Aviation"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Mirage F1, MiG-21 Fishbed, JF-17 Thunder"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Delta-wing design, single-engine, and pointed nose."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Interceptor / Multirole Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "Two 30mm DEFA cannons, up to 4,000 kg of ordnance on 5 hardpoints (including air-to-air missiles, bombs, and fuel tanks)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 15.03 meters (49 ft 4 in), Wingspan: 8.22 meters (27 ft), Height: 4.25 meters (13 ft 11 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Mirage 5, Mirage III"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted delta wings with no horizontal stabilizers, providing high-speed maneuverability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbojet engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Narrow and streamlined fuselage with a pointed nose and bubble canopy."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with no horizontal stabilizer due to the delta wing design."
+          }          
+      ]
+	},
+{
+	"key": "Mirage F1",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Dassault Aviation"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Mirage III, MiG-21 Fishbed, F-5 Tiger"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Swept-wing design, single-engine, and high-mounted wings."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Multirole Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "Two 30mm DEFA cannons, up to 6,300 kg of ordnance on 7 hardpoints (including air-to-air missiles, bombs, and fuel tanks)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 15.33 meters (50 ft 4 in), Wingspan: 8.40 meters (27 ft 7 in), Height: 4.50 meters (14 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Mirage F1"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted, swept-back wings with hardpoints for carrying ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a bubble canopy and slender nose."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "Mirage 2000",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Dassault Aviation"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Mirage III, JAS 39 Gripen, F-16 Fighting Falcon"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Delta-wing design, single-engine, and streamlined fuselage with no horizontal stabilizers."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Multirole Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "Two 30mm DEFA cannons, up to 6,300 kg of ordnance on 9 hardpoints (including air-to-air missiles, bombs, and fuel tanks)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 14.36 meters (47 ft 1 in), Wingspan: 9.13 meters (29 ft 11 in), Height: 5.20 meters (17 ft 1 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Mirage 2000"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted delta wings with no horizontal stabilizers for high-speed maneuverability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a pointed nose and bubble canopy."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with no horizontal stabilizers due to the delta wing design."
+          }          
+      ]
+	},
+{
+	"key": "Su-27 Flanker",
+	"altNames": ["Su-27, Flanker"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Sukhoi"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MiG-29 Fulcrum, F-15 Eagle, J-11"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine, large wingspan, twin vertical stabilizers, and distinctive tail boom extending beyond the engines. (Flanker with a Wanker)"
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Air Superiority Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "One 30mm GSh-30-1 cannon, up to 8,000 kg of ordnance on 10 hardpoints (including air-to-air missiles and bombs)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 21.94 meters (72 ft), Wingspan: 14.70 meters (48 ft 3 in), Height: 5.93 meters (19 ft 5 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Su-27 Flanker, Su-27, Flanker"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Large, swept-back wings with external hardpoints for ordnance and fuel tanks."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted in the rear fuselage with prominent air intakes."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and sleek fuselage with a bubble canopy and a distinctive tail boom extending beyond the engines."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers mounted widely apart at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "JAS 39 Gripen",
+	"altNames": ["JAS 39, Gripen"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Saab"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Sweden"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "F-16 Fighting Falcon, Mirage 2000, Eurofighter Typhoon"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Single-engine, delta wing design with canards for enhanced maneuverability."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Multirole Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "One 27mm Mauser BK-27 cannon, up to 5,300 kg of ordnance on 8 hardpoints (including air-to-air missiles, bombs, and fuel tanks)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 14.1 meters (46 ft 3 in), Wingspan: 8.4 meters (27 ft 7 in), Height: 4.5 meters (14 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "JAS 39 Gripen, JAS 39, Gripen"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted delta wings with canards mounted near the cockpit for increased maneuverability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Sleek and compact fuselage with a bubble canopy and blended wing-body design."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "Eurofighter Typhoon",
+	"altNames": ["Eurofighter", "Typhoon"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Eurofighter GmbH"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United Kingdom / Germany / Italy / Spain"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Dassault Rafale, F/A-18 Hornet, JAS 39 Gripen"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine, delta wing design with canards, and a high-mounted bubble canopy."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One (Single seater) or Two (Trainer version)"
+          },
+          {
+              "key": "Role",
+              "value": "Multirole Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "One 27mm Mauser BK-27 cannon, up to 7,500 kg of ordnance on 13 hardpoints (including air-to-air missiles, bombs, and fuel tanks)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 15.96 meters (52 ft 4 in), Wingspan: 10.95 meters (35 ft 11 in), Height: 5.28 meters (17 ft 4 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Eurofighter, Typhoon"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted delta wings with canards positioned near the cockpit for enhanced maneuverability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Sleek and streamlined fuselage with a bubble canopy and blended wing-body structure."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers canted outward at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "MiG-15 Fagot",
+	"altNames": ["MiG-15", "Fagot"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mikoyan"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MiG-17 Fresco"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Swept-wing design, single-engine jet with a pointed nose and bubble canopy."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Interceptor / Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "Two 23mm cannons and one 37mm cannon, external hardpoints for bombs or rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 10.11 meters (33 ft 2 in), Wingspan: 10.08 meters (33 ft 1 in), Height: 3.70 meters (12 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MiG-15 Fagot, MiG-15, Fagot"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted, swept wings with no external hardpoints for ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbojet engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined and compact fuselage with a bubble canopy and a pointed nose."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "MiG-17 Fresco",
+	"altNames": ["MiG-17, Fresco"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mikoyan"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MiG-15 Fagot"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Swept-wing design with a longer fuselage and tail compared to the MiG-15 Fagot."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Interceptor / Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "One 37mm cannon and two 23mm cannons, external hardpoints for bombs or rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11.36 meters (37 ft 3 in), Wingspan: 9.63 meters (31 ft 7 in), Height: 3.80 meters (12 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MiG-17 Fresco, MiG-17, Fresco"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted, swept wings with external hardpoints for ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbojet engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined and elongated fuselage with a pointed nose and bubble canopy."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "MiG-19 Farmer",
+	"altNames": ["MiG-19", "Farmer"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mikoyan"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MiG-17 Fresco"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine design with swept wings and a distinctive afterburner section at the rear fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Interceptor / Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "Three 30mm NR-30 cannons, external hardpoints for bombs, rockets, or air-to-air missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 12.54 meters (41 ft 2 in), Wingspan: 9.00 meters (29 ft 6 in), Height: 3.88 meters (12 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MiG-19 Farmer, MiG-19, Farmer"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted, swept wings with external hardpoints for ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbojet engines mounted in the rear fuselage with afterburners."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a bubble canopy and a prominent afterburner section at the rear."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "MiG-21 Fishbed",
+	"altNames": ["MiG-21", "Fishbed"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mikoyan"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Mirage III, JF-17 Thunder, F-5 Tiger"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Delta-wing design, single-engine, and sharp nose with a prominent air intake."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Interceptor / Multirole Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "One 23mm cannon, external hardpoints for air-to-air missiles, bombs, or rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 15.76 meters (51 ft 8 in), Wingspan: 7.15 meters (23 ft 5 in), Height: 4.12 meters (13 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MiG-21 Fishbed, MiG-21, Fishbed"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted, delta wings with external hardpoints for ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbojet engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined and slender fuselage with a prominent air intake at the nose and bubble canopy."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "MiG-25 Foxbat",
+	"altNames": ["MiG-25", "Foxbat"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mikoyan"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MiG-31 Foxhound, Su-27 Flanker"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine, large straight wings, and twin vertical stabilizers. Designed for extreme speed and high-altitude interception."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Interceptor / Reconnaissance"
+          },
+          {
+              "key": "Armament",
+              "value": "Four R-40 air-to-air missiles, no internal cannon"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 23.82 meters (78 ft 2 in), Wingspan: 13.95 meters (45 ft 9 in), Height: 6.10 meters (20 ft)"
+          },            
+          {
+              "key": "Names",
+              "value": "MiG-25 Foxbat, MiG-25, Foxbat"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Large, straight, high-mounted wings with external hardpoints for air-to-air missiles."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbojet engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Large and boxy fuselage designed for high-altitude performance, with a bubble canopy."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "MiG-27 Flogger",
+	"altNames": ["MiG-27", "Flogger"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mikoyan"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MiG-23 Flogger, Su-24 Fencer, Tornado IDS"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Variable-sweep wings, single-engine, and a reinforced nose designed for ground attack roles. Has a tail buoy that extends under the fuselage (Flogger with a dogger)"
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Ground Attack"
+          },
+          {
+              "key": "Armament",
+              "value": "One 30mm GSh-6-30 cannon, external hardpoints for air-to-ground missiles, bombs, or rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 17.10 meters (56 ft 1 in), Wingspan: 13.97 meters (45 ft 10 in) (with wings extended), Height: 5.00 meters (16 ft 5 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MiG-27 Flogger, MiG-27, Flogger"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Variable-sweep wings that can be extended for increased lift or swept back for high-speed flight."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a reinforced nose for ground attack, and a large air intake mounted high on the body."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "MiG-31 Foxhound",
+	"altNames": ["MiG-31", "Foxhound"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mikoyan"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MiG-25 Foxbat, Su-27 Flanker"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine, large straight wings, and twin vertical stabilizers. Designed for high-speed interception with long-range capabilities."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Interceptor"
+          },
+          {
+              "key": "Armament",
+              "value": "One 23mm GSh-6-23 cannon, up to 4,500 kg of ordnance on external hardpoints (air-to-air missiles)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 22.69 meters (74 ft 5 in), Wingspan: 13.46 meters (44 ft 2 in), Height: 6.15 meters (20 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MiG-31 Foxhound, MiG-31, Foxhound"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Large, straight, high-mounted wings with external hardpoints for air-to-air missiles."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Large, streamlined fuselage designed for high-speed interception, with a tandem cockpit for two crew members."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "Su-57 Felon",
+	"altNames": ["Su-57", "Felon"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Sukhoi"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "F-22 Raptor, J-20"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Stealth fighter with a unique forward-swept wing design and advanced avionics for enhanced agility and reduced radar cross-section."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": ": Air Superiority / Multirole Stealth Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "30 mm cannon, air-to-air missiles, air-to-surface missiles, bombs"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 19.8 meters (65 ft 0 in), Wingspan: 14.0 meters (45 ft 11 in), Height: 4.8 meters (15 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Su-57 Felon, Su-57, Felon"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Mid-mounted, trapezoidal wings with slight forward sweep for enhanced maneuverability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two afterburning turbofan engines with vectored thrust nozzles for superior agility."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Sleek fuselage with a flat-sided design for reduced radar cross-section and internal weapon bays for stealth capability."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers with outward canted configuration to reduce radar signature and improve stability."
+          }          
+      ]
+	},
+{
+	"key": "J-20 Fagin",
+	"altNames": ["J-20", "Fagin"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Chengdu Aerospace Corporation"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "China"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Su-57 Felon, F-22 Raptor"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Stealth fighter with canard foreplanes and a long, sleek fuselage designed for long-range strike and air superiority roles."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Air Superiority / Multirole Stealth Fighter"
+          },
+          {
+              "key": "Armament",
+              "value": "Internal weapon bays for air-to-air and air-to-surface missiles, bombs, 30 mm cannon"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 20.3 meters (66 ft 7 in), Wingspan: 13.5 meters (44 ft 3 in), Height: 4.45 meters (14 ft 7 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "J-20 Fagin, J-20, Fagin"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Delta wing design with large surface area, mid-mounted, for improved lift and agility."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines with low observable exhaust nozzles for stealth capabilities."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long, sleek fuselage with a faceted design to reduce radar signature and internal weapon bays for stealth."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin vertical stabilizers with outward canted configuration to reduce radar cross-section."
+          }          
+      ]
+	},
+{
+	"key": "B-1B Lancer",
+	"altNames": ["B-1B", "Lancer"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Rockwell International"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Tu-160 Blackjack, B-52 Stratofortress"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Variable-sweep wings, twin-engine design, and large bomb bays for heavy payloads."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "Strategic Bomber"
+          },
+          {
+              "key": "Armament",
+              "value": "Up to 34,000 kg of ordnance (including bombs and cruise missiles) in internal bays"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 44.81 meters (146 ft 11 in), Wingspan: 41.67 meters (136 ft 8 in) (with wings extended), Height: 10.36 meters (34 ft)"
+          },            
+          {
+              "key": "Names",
+              "value": "B-1B Lancer, B-1B, Lancer"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Variable-sweep wings that adjust for high-speed flight and long-range missions."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and sleek fuselage with large internal bomb bays."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "B-2 Spirit",
+	"altNames": ["B-2", "Spirit"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Northrop Grumman"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Unique Aircraft"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Flying wing design with no vertical stabilizers, designed for stealth."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Strategic Stealth Bomber"
+          },
+          {
+              "key": "Armament",
+              "value": "Up to 18,000 kg of ordnance (including bombs and cruise missiles) in internal bays"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 21.03 meters (69 ft), Wingspan: 52.12 meters (171 ft), Height: 5.18 meters (17 ft)"
+          },            
+          {
+              "key": "Names",
+              "value": "B-2 Spirit, B-2, Spirit"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Blended wing-body design with no distinct fuselage, part of the stealth features."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Four turbofan engines buried within the wing structure for reduced radar signature."
+          },
+          {
+              "key": "Fuselage",
+              "value": "No traditional fuselage; the design is entirely a flying wing structure."
+          },     
+          {
+              "key": "Tail",
+              "value": "No vertical stabilizers; the flying wing design eliminates a traditional tail."
+          }          
+      ]
+	},
+{
+	"key": "B-52 Stratofortress",
+	"altNames": ["B-52", "Stratofortress"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Tu-95 Bear"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Eight-engine design with long, straight wings and a distinctive tail."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Five"
+          },
+          {
+              "key": "Role",
+              "value": "Strategic Bomber"
+          },
+          {
+              "key": "Armament",
+              "value": "Up to 31,500 kg of ordnance (including bombs, cruise missiles, and mines) in internal bays and on external pylons"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 48.5 meters (159 ft 4 in), Wingspan: 56.4 meters (185 ft), Height: 12.4 meters (40 ft 8 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "B-52 Stratofortress, B-52, Stratofortress"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Long, straight, high-mounted wings with external hardpoints for ordnance and fuel tanks."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Eight turbofan engines mounted in four nacelles under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and cylindrical fuselage with a tandem cockpit and large bomb bays."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer mounted on the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "Tu-95 Bear",
+	"altNames": ["Tu-95", "Bear"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Tupolev"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "B-52 Stratofortress, Tu-142"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Four turboprop engines with counter-rotating propellers, long straight wings, and a tail gunner position."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Seven"
           },
           {
-              "key": "Role:",
-              "value": "Strategic heavy-lift cargo aircraft for transporting oversized equipment, vehicles, and troops"
+              "key": "Role",
+              "value": "Strategic Bomber / Maritime Patrol"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "Up to 15,000 kg of ordnance (including bombs, cruise missiles)"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 247 ft, 1 in (75.3 m), Span: 222 ft, 9 in (67.9 m) "
+              "key": "Dimensions",
+              "value": "Length: 46.2 meters (151 ft 7 in), Wingspan: 50.1 meters (164 ft 5 in), Height: 12.12 meters (39 ft 9 in)"
           },            
           {
-              "key": "Names:",
+              "key": "Names",
+              "value": " TU-95 Bear, TU-95, Bear"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Long, straight, mid-mounted wings with four engine nacelles, each containing counter-rotating propellers."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Four turboprop engines with large counter-rotating propellers."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long cylindrical fuselage with a tandem cockpit and tail gunner position."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "Tu-160 Blackjack",
+	"altNames": ["Tu-160", "Blackjack"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Tupolev"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "B-1B Lancer"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Variable-sweep wings, twin-engine design, and large internal bomb bays for heavy payloads."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "Strategic Bomber"
+          },
+          {
+              "key": "Armament",
+              "value": "Up to 40,000 kg of ordnance (including bombs and cruise missiles) in internal bays"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 54.1 meters (177 ft 6 in), Wingspan: 55.7 meters (182 ft 9 in) (with wings extended), Height: 13.1 meters (42 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "TU-160 Blackjack, TU-160, Blackjack"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Variable-sweep wings that adjust for high-speed flight and long-range missions."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and sleek fuselage with large internal bomb bays."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "Tu-22M Backfire",
+	"altNames": ["Tu-22M", "Backfire"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Tupolev"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Su-24 Fencer, B-1B Lancer"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Variable-sweep wings, twin-engine design, and large bomb bays for heavy payloads."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "Strategic Bomber"
+          },
+          {
+              "key": "Armament",
+              "value": "Up to 24,000 kg of ordnance (including bombs and cruise missiles)"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 42.46 meters (139 ft 4 in), Wingspan: 34.28 meters (112 ft 6 in) (with wings extended), Height: 11.05 meters (36 ft 3 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Tu-22M Backfire, Tu-22M, Backfire"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Variable-sweep wings that adjust for high-speed flight and long-range missions."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and streamlined fuselage with large internal bomb bays."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
+          }          
+      ]
+	},
+{
+	"key": "An-124 Condor",
+	"altNames": ["An-124", "Condor"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Antonov"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Ukraine/ Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "C-5 Galaxy"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "High-mounted wings, four turbofan engines, and a large cargo hold capable of carrying oversized equipment."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Six"
+          },
+          {
+              "key": "Role",
+              "value": "Heavy Transport"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 68.96 meters (226 ft 3 in), Wingspan: 73.30 meters (240 ft 6 in), Height: 20.78 meters (68 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "An-124 Condor, An-124, Condor"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted, straight wings with four engine nacelles, each housing a turbofan engine."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Large and bulky fuselage designed for heavy cargo transport, with a nose section that can be raised for loading."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer mounted at the rear with a large horizontal stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "C-5 Galaxy",
+	"altNames": ["C-5", "Galaxy"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Lockheed Martin"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "An-124 Condor, C-17"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "High-mounted wings, four turbofan engines, and a large cargo hold for oversized equipment. The Tail makes a captail 'T' Shape, the wing do NOT have winglets "
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Seven"
+          },
+          {
+              "key": "Role",
+              "value": "Heavy Transport"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 75.31 meters (247 ft 1 in), Wingspan: 67.89 meters (222 ft 8 in), Height: 19.84 meters (65 ft 1 in)"
+          },            
+          {
+              "key": "Names",
               "value": "C-5 Galaxy, C-5, Galaxy"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "High-mounted, swept-back wings with a slight taper and large fuel tanks integrated into the wing structure."
+              "key": "Wings",
+              "value": "High-mounted, straight wings with four engine nacelles, each housing a turbofan engine."
           },
           {
-              "key": "Engine(s):",
-              "value": "Four turbofan engines mounted under the wings, evenly spaced, extending forward from the wings' leading edges."
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted under the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Massive, long fuselage with a wide, bulbous nose. The aircraft features both nose and tail loading doors for cargo, with the nose capable of tilting upward for access. The upper deck is reserved for crew and additional passengers, with the lower deck used for cargo."
+              "key": "Fuselage",
+              "value": "Long and bulky fuselage designed for heavy cargo transport, with a nose section that can be raised for loading."
           },     
           {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single large vertical stabilizer and high-mounted horizontal stabilizers. This setup enhances stability and control, especially for such a large aircraft."
+              "key": "Tail",
+              "value": "Single vertical stabilizer mounted at the rear with a large horizontal stabilizer."
           }          
       ]
 	},
-    {
-	"key": "C-17 Globemaster",
-	"altNames": ["C-17", "Globemaster", "Globemaster III", "C-17 Globemaster II"], 
-	"tags": ["Plane", "Cargo Plane", "Heavy-Lift", "Transport Aircraft", "Strategic Airlift", "Tactical Airlift", "Four Engines", "Short Takeoff and Landing", "Military Transport", "Medical Evacuation", "Rapid Deployment", "High Capacity", "Austere Runways"],
-	"hltag": ["NCR"],
+{
+	"key": "An-12 Cub",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Boeing"
+              "key": "Manufacturer",
+              "value": "Antonov"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "Russia"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "C-5 Galaxy, AN-124 Condor, C-130 Hercules"
+              "key": "Similar Aircraft",
+              "value": "C-130 Hercules"
+              
           },
           {
-              "key": "Crew:",
-              "value": "Three"
+              "key": "Distinctive Features",
+              "value": "High-mounted wings, four turboprop engines, and a large rear cargo door for loading."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Six"
           },
           {
-              "key": "Role:",
-              "value": "Tactical and strategic airlift for cargo and troop transport, medical evacuation"
+              "key": "Role",
+              "value": "Tactical Transport"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "Unarmed"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 174 ft (53 m), Span: 169 ft, 10 in (51.75 m)"
+              "key": "Dimensions",
+              "value": "Length: 33.10 meters (108 ft 7 in), Wingspan: 38.00 meters (124 ft 8 in), Height: 10.53 meters (34 ft 7 in)"
           },            
           {
-              "key": "Names:",
-              "value": "C-17 Globemaster, C-17, Globemaster"
+              "key": "Names",
+              "value": "An-12 Cub, An-12, Cub"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "High-mounted, swept-back wings with slight taper and winglets at the tips for enhanced aerodynamics."
+              "key": "Wings",
+              "value": "High-mounted, straight wings with four turboprop engines."
           },
           {
-              "key": "Engine(s):",
-              "value": "Four turbofan engines mounted under the wings, positioned close to the fuselage for better control during short landings and takeoffs."
+              "key": "Engine(s)",
+              "value": "Four turboprop engines mounted under the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Large, sleek fuselage with a bulbous nose. The fuselage is designed to carry heavy cargo, vehicles, and personnel, featuring a rear loading ramp for rapid offloading of supplies or equipment. The fuselage tapers slightly toward the rear."
+              "key": "Fuselage",
+              "value": "Cylindrical fuselage with a rear cargo door for loading and unloading equipment."
           },     
           {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single large vertical stabilizer and high-mounted horizontal stabilizers, providing control and stability during heavy-lift operations."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
           }          
       ]
 	},
-    {
-	"key": "C-130 Hercules",
-	"altNames": ["C-130", "Hercules"], 
-	"tags": ["Plane", "Cargo Plane", "Heavy-Lift", "Transport Aircraft", "Tactical Airlift", "Four Engines", "Short Takeoff and Landing", "Military Transport", "Medical Evacuation", "Paratroop Transport", "Aerial Refueling", "Firefighting", "Austere Runways", "Search and Rescue"],
+{
+	"key": "C-17 Globemaster III",
+	"altNames": ["C-17", "Globemaster III", "C-17 Globemaster", "Globemaster"], 
+	"tags": [],
 	"hltag": ["NCR"],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Lockheed"
+              "key": "Manufacturer",
+              "value": "Boeing"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "C-160 Transall, C-17 Globemaster III"   
+              "key": "Similar Aircraft",
+              "value": "IL-76 Candid"
+              
           },
           {
-              "key": "Crew:",
-              "value": "Five "
+              "key": "Distinctive Features",
+              "value": "High-mounted wings, four turbofan engines, and a large rear cargo ramp for loading."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Three"
           },
           {
-              "key": "Role:",
-              "value": "Tactical airlift for cargo and personnel transport, medical evacuation, and specialized missions"
+              "key": "Role",
+              "value": "Strategic and Tactical Airlift"
           },
           {
-              "key": "Armament:",
-              "value": "None in standard transport configurations, but can be equipped with defensive countermeasures"
+              "key": "Armament",
+              "value": "Unarmed"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 97 ft, 9 in (29.8 m), Span: 132 ft, 7 in (40.4 m)"
+              "key": "Dimensions",
+              "value": "Length: 53.04 meters (174 ft), Wingspan: 51.75 meters (169 ft 10 in), Height: 16.79 meters (55 ft 1 in)"
           },            
           {
-              "key": "Names:",
+              "key": "Names",
+              "value": "C-17 Globemaster, C-17 Globemaster III, C-17, Globemaster III, Globemaster"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted, swept-back wings with four engine nacelles, each housing a turbofan engine."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Large and robust fuselage with a rear cargo ramp for easy loading and unloading."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a large horizontal stabilizer at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "C-130 Hercules",
+	"altNames": ["C-130", "Hercules", "C-130J", "Super Hercules"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Lockheed Martin"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "An-12 Cub"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "High-mounted wings, four turboprop engines, and a rear cargo door for loading."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Five"
+          },
+          {
+              "key": "Role",
+              "value": "Tactical Airlift"
+          },
+          {
+              "key": "Armament",
+              "value": "Typically Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 29.79 meters (97 ft 9 in), Wingspan: 40.41 meters (132 ft 7 in), Height: 11.90 meters (39 ft 1 in)"
+          },            
+          {
+              "key": "Names",
               "value": "C-130 Hercules, C-130, Hercules"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "High-mounted, straight wings with wide span and square tips. The wings are designed for efficient short takeoff and landing capabilities."
+              "key": "Wings",
+              "value": "High-mounted, straight wings with four turboprop engines."
           },
           {
-              "key": "Engine(s):",
-              "value": "Four turboprop engines mounted under the wings, each with large, six-blade propellers for maximum lift and performance, especially in austere environments."
+              "key": "Engine(s)",
+              "value": "Four turboprop engines mounted under the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Large, cylindrical fuselage with a blunt nose and stepped cockpit. The fuselage is optimized for cargo and personnel, featuring side doors for parachute operations and a rear ramp for loading large cargo or vehicles."
+              "key": "Fuselage",
+              "value": "Cylindrical fuselage with a rear cargo door for loading and unloading equipment."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail with a single vertical stabilizer and low-mounted horizontal stabilizers, This configuration provides stability during heavy-lift operations and ensures control during short takeoff and landing scenarios."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
           }          
       ]
 	},
-    {
-	"key": "ATR-72",
-	"altNames": ["ATR 72"], 
-	"tags": ["Plane", "Turboprop", "Regional Airliner", "Passenger Transport", "Cargo Plane", "Short-Haul", "Twin Engines", "Commercial Aircraft", "Civil Aviation", "Utility Aircraft"],
-	"hltag": ["NCR"],
+{
+	"key": "C-160 Transall",
+	"altNames": ["C-160", "Transall"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Aerei da Trasporto Reginale "
+              "key": "Manufacturer",
+              "value": "Nord Aviation / MBB"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "France/ Italy"
+              "key": "Country of Origin",
+              "value": "France / Germany"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Dash 8, Beechcraft King Air"
+              "key": "Similar Aircraft",
+              "value": "C-130 Hercules, An-12 Cub"
               
           },
           {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Regional airliner for short to medium-haul flights, capable of cargo and passenger transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 89 ft (27 m), Span: 88 ft, 9 in (27.05 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "ATR-72"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "High-mounted, straight wings with square tips and large nacelles for the engines."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turboprop engines mounted under the wings, each with large, six-blade propellers. The engines are positioned close to the fuselage, providing better weight distribution and control during flight."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Narrow and cylindrical fuselage with a slightly pointed nose, designed for efficient regional transport. The fuselage is elongated to accommodate passengers and cargo, with multiple windows along the sides."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail with a single vertical stabilizer and a low-mounted horizontal stabilizer, giving the aircraft stability during its relatively low-speed, short-haul operations."
-          }          
-      ]
-	},
-    {
-	"key": "Beechcraft Baron",
-	"altNames": ["Beech Baron"],
-	"tags": ["Plane", "Piston Engine", "Light Aircraft", "Twin Engines", "Private Aircraft", "General Aviation", "Utility Aircraft", "Transport", "Training Aircraft"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Beechcraft"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Beechcraft Bonanza, Cessna 310"
+              "key": "Distinctive Features",
+              "value": "High-mounted wings, two turboprop engines, and a rear cargo door for loading."
               
           },
+
           {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "Light utility aircraft for private transport, training, and regional travel"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 29 ft, 10 in (9.1 m), Span: 37 ft, 10 in (11.53 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Beechcraft Baron, Beech Baron"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, straight wings with square tips."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two piston engines mounted on the wings, with propellers extending beyond the leading edges of the wings."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Narrow fuselage with a slightly pointed nose. The cockpit is located forward with large windows providing excellent visibility. The body is streamlined and narrow to accommodate passengers and light cargo."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail with a single vertical stabilizer and low-mounted horizontal stabilizers. The tail design is similar to that of other light utility aircraft, offering stability and control."
-          }          
-      ]
-	},
-    {
-	"key": "Beechcraft Bonanza",
-	"altNames": ["Beech Bonanza"],
-	"tags": ["Plane", "Piston Engine", "Single Engine", "Light Aircraft", "Private Aircraft", "General Aviation", "Utility Aircraft", "Transport", "Training Aircraft", "Recreational Aircraft"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Beechcraft"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Beechcraft Baron, Cessna 172"
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "Light aircraft for private transport, training, and recreational flying"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 26 ft, 5 in (8.05 m), Span: 33 ft, 6 in (10.21 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Beechcraft Bonanza, Beech Bonanza"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, straight wings with rounded tips."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "One piston engine mounted in the nose, with a single propeller."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Narrow and elongated fuselage with a pointed nose. The cabin is enclosed with large windows, providing good visibility."
-          },     
-          {
-              "key": "Tail:",
-              "value": "The early model features the distinctive V-tail configuration, also known as a 'butterfly tail', with two rotors angled outward, serving the function of both the rudder and elevator. This unique tail design gives the Bonanza its recognizable silhouette."
-          }          
-      ]
-	},
-    {
-	"key": "Cessna 310",
-	"altNames": [""],
-	"tags": ["Plane", "Twin Engines", "Piston Engine", "Light Aircraft", "Private Aircraft", "General Aviation", "Utility Aircraft", "Transport", "Air Taxi", "Regional Travel"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Cessna"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Beechcraft Baron, Piper PA-28 Cherokee"
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "Light twin-engine aircraft for private transport, air taxi, and regional travel"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 27 ft, 0 in (8.23 m), Span: 35 ft, 9 in (10.9 m) "
-          },            
-          {
-              "key": "Names:",
-              "value": "Cessna 310"
-          }                     
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, straight wings with tip tanks for additional fuel storage. The wing design allows for improved range and performance."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two piston engines mounted on the wings, with propellers extending beyond the leading edges."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Streamlined, narrow fuselage with a slightly pointed nose. The cabin has large windows, providing visibility for both the pilot and passengers. The overall design is optimized for light passenger transport."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail with a single vertical stabilizer and low-mounted horizontal stabilizers. The tail design offers stability and control during flight, characteristic of many light twin-engine aircraft."
-          }          
-      ]
-	},
-    {
-	"key": "Piper PA-28 Cherokee",
-	"altNames": ["PA-28", "Piper Cherokee"],
-	"tags": ["Plane", "Single Engine", "Piston Engine", "Light Aircraft", "Private Aircraft", "General Aviation", "Training Aircraft", "Recreational Aircraft", "Utility Aircraft", "Transport"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Piper Aircrafts"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Cessna 172, Beechcraft Bonanza"
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "Light aircraft for private transport, training, and recreational flying"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 24 ft, 7 in (7.49 m), Span: 30 ft, 0 in (9.14 m) "
-          },            
-          {
-              "key": "Names:",
-              "value": "Piper PA-28 Cherokee, PA-28, Piper Cherokee"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, straight wings with rounded tips, designed for stable and predictable handling, making it ideal for training purposes."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Single piston engine mounted in the nose with a single propeller."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Narrow, elongated fuselage with a pointed nose and enclosed cabin. The aircraft has large side windows for visibility and comfort, typical for light personal and training aircraft."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail with a single vertical stabilizer and low-mounted horizontal stabilizers, providing stability and control during flight."
-          }          
-      ]
-	},
-    {
-	"key": "Piper PA-18 Cub",
-	"altNames": ["Piper Cub", "PA-18"], 
-	"tags": ["Plane", "Single Engine", "Piston Engine", "Light Aircraft", "Utility Aircraft", "General Aviation", "Recreational Aircraft", "STOL", "Bush Plane", "Training Aircraft", "Private Aircraft"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Piper Aircrafts"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Piper J-3 Cub, Cessna 170"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "Light utility aircraft for bush flying, training, and general aviation"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 22 ft, 7 in (6.88 m), Span: 35 ft, 3 in (10.74 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Piper PA-18 Cub, Piper Cub "
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "High-mounted, straight wings with rounded tips and external struts for added support and stability. The high-wing configuration gives it excellent ground visibility and helps with STOL (short takeoff and landing) capabilities."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Single piston engine mounted in the nose, with a two-blade propeller. The engine is typically more powerful than the J-3 Cub, enabling the Super Cub's improved performance."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Narrow fuselage with tandem seating for two (pilot and passenger). The fuselage is enclosed with large windows, offering good visibility for bush flying and observation roles."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single vertical stabilizer and low-mounted horizontal stabilizers, offering stability during flight, especially at low speeds."
-          }       
-      ]
-	},
-    {
-	"key": "Dash 8",
-	"altNames": [""], 
-	"tags": ["Plane", "Twin Engines", "Turboprop", "Regional Airliner", "Passenger Aircraft", "Cargo Aircraft", "Short-Haul", "Medium-Haul", "Civil Aviation"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "De Havilland Canada "
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "Canada"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "ATR 72, Saab 340"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Regional airliner for short to medium-haul flights"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 80 ft, 7 in (24.61 m), Span: 93 ft, 3 in (28.42 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Dash 8"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": " High-mounted, straight wings with winglets and large nacelles to house the engines."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turboprop engines mounted under the wings, with six-blade propellers extending beyond the leading edge of the wings."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Long and cylindrical fuselage with a rounded nose and multiple windows along the sides for passengers. The design is optimized for efficient regional transport, offering stability and fuel efficiency."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail with a single vertical stabilizer and high-mounted horizontal stabilizers, providing stability during flight."
-          }          
-      ]
-	},
-    {
-	"key": "Cessna 421 Golden Eagle",
-	"altNames": ["Cessna 421", "Golden Eagle"],
-	"tags": ["Plane", "Twin Engines", "Piston Engine", "Light Aircraft", "Business Aircraft", "Private Aircraft", "General Aviation", "Executive Transport"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Cessna"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "USA"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Beechcraft Baron, Cessna 310"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "Light transport aircraft, primarily used for business aviation and personal transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 36 ft, 1 in (11.00 m), Span: 41 ft, 1 in (12.52 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Cessna 421 Golden Eagle, Cessna 421, Golden Eagle"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, straight wings with rounded tips, housing engine nacelles on each side."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two piston engines mounted under the wings, each driving a three-blade propeller."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Long, narrow fuselage with a rounded nose, a large windshield, and multiple circular windows along the sides. The design focuses on maximizing cabin comfort for passengers in business travel configurations."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single vertical stabilizer and low-mounted horizontal stabilizers, offering stability and control during flight."
-          }          
-      ]
-	},
-    {
-	"key": "Beechcraft King Air",
-	"altNames": ["Beech King Air"], 
-	"tags": ["Plane", "Twin Engines", "Turboprop", "Utility Aircraft", "Business Aircraft", "Private Aircraft", "General Aviation", "Executive Transport", "Reconnaissance", "Light Cargo"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Beechcraft"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Beechcraft Baron, Cessna 421 Golden Eagle"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Utility, executive transport, reconnaissance, and light cargo aircraft"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 43 ft 10 in (13.36 m), Span: 54 ft 6 in (16.61 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Beechcraft King Air, Beech King Air"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, straight wings with rounded tips, equipped with engine nacelles and winglets at the tips."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two engines mounted under the wings, each driving a multi-bladed propeller."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Long, narrow fuselage with a rounded nose, large rectangular windows along the side, and a cabin configured for passenger comfort or mission-specific equipment."
-          },     
-          {
-              "key": "Tail:",
-              "value": "T-tail configuration with a high-mounted horizontal stabilizer on the vertical fin, providing good stability and control during flight."
-          }         
-      ]
-	},
-    {
-	"key": "Mooney M-22 Mustang",
-	"altNames": ["Mooney M-22", "Mooney Mustang"], 
-	"tags": ["Plane", "Single Engine", "Piston Engine", "General Aviation", "Light Aircraft", "Private Aircraft", "Personal Transport", "Utility Aircraft", "Touring Aircraft"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Mooney Aircraft Company"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Piper Cherokee, Beechcraft Bonanza"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "General aviation, personal transport, and utility aircraft"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 23 ft 3 in (7.09 m), Span: 32 ft 8 in (9.96 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Mooney M-22 Mustang, Mooney M-22, Mooney Mustang"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, straight wings with squared tips."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Single-engine mounted at the nose, driving a two-bladed propeller."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Streamlined and narrow with a pointed nose, a single front windscreen, and side windows along the length of the fuselage."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail arrangement with a distinctive vertical stabilizer that features an angled top and a broad rudder surface."
-          }         
-      ]
-	},
-    {
-	"key": "MV-22 Osprey",
-	"altNames": ["MV-22", "Osprey"],
-	"tags": ["Rotorcraft", "Tiltrotor", "Multirole Aircraft", "Military Aircraft", "Transport Aircraft", "Vertical Takeoff", "VTOL", "STOL", "Cargo Transport", "Troop Transport", "Helicopter"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Bell Boeing"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "None (unique tiltrotor aircraft)"
-              
-          },
-          {
-              "key": "Crew:",
+              "key": "Crew",
               "value": "Four"
           },
           {
-              "key": "Role:",
-              "value": "Multirole combat, transport, and logistics aircraft"
+              "key": "Role",
+              "value": "Tactical Transport"
           },
           {
-              "key": "Armament:",
-              "value": "Typically unarmed, but can be equipped with various weapons like a belly-mounted M240 machine gun or a ramp-mounted GAU-17/A minigun"
+              "key": "Armament",
+              "value": "Unarmed"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 57 ft 4 in (17.48 m), Rotor diameter: 38 ft (11.6 m)"
+              "key": "Dimensions",
+              "value": "Length: 32.40 meters (106 ft 4 in), Wingspan: 40 meters (131 ft 3 in), Height: 11.60 meters (38 ft 1 in)"
           },            
           {
-              "key": "Names:",
-              "value": "MV-22 Osprey, MV-22, Osprey"
+              "key": "Names",
+              "value": "C-160 Transall, C-160, Transall"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "High-mounted, straight wings with two large nacelles housing the engines and rotors, which tilt to facilitate both vertical and horizontal flight."
+              "key": "Wings",
+              "value": "High-mounted, straight wings with two turboprop engines."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two Rolls-Royce T406 turboshaft engines, mounted in nacelles on each wingtip, each driving a three-bladed tiltrotor."
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted under the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Long and boxy fuselage with a distinctive angled nose, large cockpit windows, and a rear loading ramp."
+              "key": "Fuselage",
+              "value": "Cylindrical fuselage with a rear cargo door for loading and unloading equipment."
           },     
           {
-              "key": "Tail:",
-              "value": "Twin vertical stabilizers mounted on a horizontal tailplane."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
           }          
       ]
 	},
-    {
-	"key": "Saab 340",
-	"altNames": [""],
-	"tags": ["Plane", "Turboprop", "Twin Engines", "Regional Airliner", "Passenger Aircraft", "Cargo Aircraft", "Short-Haul", "Transport Aircraft"],
-	"hltag": ["NCR"],
+{
+	"key": "IL-76 Candid",
+	"altNames": ["IL-76", "Candid"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Sweden"
+              "key": "Manufacturer",
+              "value": "Ilyushin"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "Embraer EMB 120, Fairchild Metro"
+              "key": "Country of Origin",
+              "value": "Russia"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": ""
+              "key": "Similar Aircraft",
+              "value": "C-17 Globemaster III, An-124 Condor"
               
           },
           {
-              "key": "Crew:",
-              "value": "Two"
+              "key": "Distinctive Features",
+              "value": "High-mounted wings, four turbofan engines, and a large rear cargo door for loading."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Seven"
           },
           {
-              "key": "Role:",
-              "value": "Regional airliner, cargo, and military transport"
+              "key": "Role",
+              "value": "Strategic and Tactical Airlift"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "Unarmed"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 64 ft 9 in (19.7 m), Wingspan: 70 ft 4 in (21.4 m)"
+              "key": "Dimensions",
+              "value": "46.59 meters (152 ft 10 in), Wingspan: 50.50 meters (165 ft 8 in), Height: 14.76 meters (48 ft 5 in)"
           },            
           {
-              "key": "Names:",
-              "value": "Saab 340"
+              "key": "Names",
+              "value": "IL-76 Candid, IL-76, Candid"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, straight wings with two underslung engine nacelles housing the turboprop engines. The wings are clean and unobstructed with no winglets."
+              "key": "Wings",
+              "value": "High-mounted, swept-back wings with four turbofan engines mounted in nacelles under the wings."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turboprop engines driving four-bladed propellers located on each wing, just outside the fuselage."
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted under the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Tubular fuselage with a flat bottom and rounded top, featuring several round windows. The nose is slightly pointed, and the fuselage is long and narrow."
+              "key": "Fuselage",
+              "value": "Long and cylindrical fuselage with a rear cargo door for easy loading and unloading."
           },     
           {
-              "key": "Tail:",
-              "value": "T-tail configuration with straight horizontal stabilizers mounted on top of the vertical stabilizer, giving it a distinctive T-shape."
-          }         
-      ]
-	},
-    {
-	"key": "Cessna 172 Skyhawk",
-	"altNames": ["Cessna 172", "Skyhawk"],
-	"tags": ["Plane", "Piston Engine", "Single Engine", "General Aviation", "Trainer Aircraft", "Light Aircraft", "Private Transport", "Flight Training"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Cessna"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Piper J-3 Cub, Piper PA-18 Super Cub"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "General aviation, flight training, personal use"
-          },
-          {
-              "key": "Armament:",
-              "value": "Typically unarmed"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 27 ft 2 in (8.28 m), Wingspan: 36 ft 1 in (11.0 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Cessna 172 Skyhawk, Cessna 172, Skyhawk"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "High-mounted, straight wings with wing struts connecting the wing to the fuselage."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Single piston engine located at the front with a two-bladed propeller."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Small and narrow, with a tubular design and a rounded nose."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail design with straight horizontal and vertical stabilizers."
-          }         
-      ]
-	},
-    {
-	"key": "SR-22",
-	"altNames": [""],
-	"tags": ["Plane", "Piston Engine", "Single Engine", "General Aviation", "Private Transport", "High Performance Aircraft", "Flight Training", "Personal Aircraft"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Cirrus Aircrafts"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Cessna 310, Piper PA-28 Cherokee, Cessna TTx"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "General aviation, personal use, and flight training"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 26 ft (7.92 m), Wingspan: 38 ft 4 in (11.68 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "SR-22"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, straight wings with slightly tapered wingtips."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Single piston engine at the front with a three-bladed propeller."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Sleek, aerodynamic fuselage made from composite materials with a side stick control."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Single tail configuration with straight horizontal stabilizers."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
           }          
       ]
 	},
-    {
-	"key": "Airbus A300",
-	"altNames": ["Airbus 300, A300"], 
-	"tags": ["Plane", "Jet", "Twin Engines", "Wide-Body", "Commercial Aircraft", "Passenger Transport", "Cargo Transport", "Medium-Haul", "Long-Haul"],
-	"hltag": ["NCR"],
+{
+	"key": "An-72 Coaler",
+	"altNames": ["An-72", "Coaler"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Airbus"
+              "key": "Manufacturer",
+              "value": "Antonov"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "France"
+              "key": "Country of Origin",
+              "value": "Ukraine"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "McDonnell Douglas DC-10, Boeing 767"
+              "key": "Similar Aircraft",
+              "value": "C-212 Aviocar"
               
           },
           {
-              "key": "Crew:",
-              "value": "Two"
+              "key": "Distinctive Features",
+              "value": "High-mounted wings with engines mounted above the wings, and a distinctive upward tilt of the fuselage for short takeoff and landing (STOL) capabilities."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Five"
           },
           {
-              "key": "Role:",
-              "value": "Cargo transport"
+              "key": "Role",
+              "value": "Tactical Airlift"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "Unarmed"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 54.1 m (177 ft), Wingspan: 44.84 m (147 ft), Height: 16.5 m (54 ft)"
+              "key": "Dimensions",
+              "value": "Length: 28.07 meters (92 ft 1 in), Wingspan: 31.89 meters (104 ft 7 in), Height: 8.65 meters (28 ft 5 in)"
           },            
           {
-              "key": "Names:",
-              "value": "Airbus 300, Airbus A300, A300"
+              "key": "Names",
+              "value": "An-72 Coaler, An-72, Coaler"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with large winglets."
+              "key": "Wings",
+              "value": "High-mounted, swept-back wings with two turbofan engines mounted above the wings for enhanced short takeoff and landing capabilities."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two underwing-mounted turbofan engines."
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted above the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Wide-body fuselage with a cylindrical shape designed for carrying large cargo loads."
+              "key": "Fuselage",
+              "value": "Compact fuselage with a raised rear cargo ramp for loading."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail with a tall vertical stabilizer and a high-mounted horizontal stabilizer."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a T-tail configuration."
           }          
       ]
 	},
-    {
-	"key": "Airbus A320",
-	"altNames": ["Airbus 320", "A320"], 
-	"tags": ["Plane", "Jet", "Twin Engines", "Narrow-Body", "Commercial Aircraft", "Passenger Transport", "Short-Haul", "Medium-Haul"],
-	"hltag": ["NCR"],
+{
+	"key": "C-212 Aviocar",
+	"altNames": ["C-212", "Aviocar"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Airbus"
+              "key": "Manufacturer",
+              "value": "CASA"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "France"
+              "key": "Country of Origin",
+              "value": "Spain"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Aircraft: Boeing 737, Airbus A321"
+              "key": "Similar Aircraft",
+              "value": "An-72 Coaler, C-23 Sherpa"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "High-mounted wings, twin turboprop engines, and a boxy fuselage for short-haul transport missions."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "Passenger transport"
+              "key": "Role",
+              "value": "Tactical Transport"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "Unarmed"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 37.57 m (123 ft 3 in), Wingspan: 34.10 m (111 ft 10 in), Height: 11.76 m (38 ft 7 in)"
+              "key": "Dimensions",
+              "value": "Length: 16.15 meters (53 ft), Wingspan: 20.28 meters (66 ft 7 in), Height: 6.60 meters (21 ft 8 in)"
           },            
           {
-              "key": "Names:",
-              "value": "Airbus 320, Airbus A320, A320"
+              "key": "Names",
+              "value": "C-212 Aviocar, C-212, Aviocar"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with small winglets at the tips."
+              "key": "Wings",
+              "value": "High-mounted, straight wings with two turboprop engines."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two underwing-mounted turbofan engines."
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted under the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Cylindrical, narrow-body fuselage with single-aisle configuration for passengers."
+              "key": "Fuselage",
+              "value": "Two turboprop engines mounted under the wings."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail with a vertical stabilizer and a low-mounted horizontal stabilizer."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail layout."
           }          
       ]
 	},
-    {
-	"key": "Airbus A330",
-	"altNames": ["Airbus 330", "A330"], 
-	"tags": ["Plane", "Jet", "Twin Engines", "Wide-Body", "Commercial Aircraft", "Passenger Transport", "Long-Haul", "Cargo Transport"],
-	"hltag": ["NCR"],
+{
+	"key": "C-23 Sherpa",
+	"altNames": ["C-23, Sherpa"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Airbus"
+              "key": "Manufacturer",
+              "value": "Short Brothers"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "France"
+              "key": "Country of Origin",
+              "value": "United Kingdom"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Boeing 777, Airbus A340"
+              "key": "Similar Aircraft",
+              "value": "C-212 Aviocar, An-72 Coaler"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Boxy fuselage with high-mounted wings and twin turboprop engines."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "Long-haul passenger transport"
+              "key": "Role",
+              "value": "Tactical Transport"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "Unarmed"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 63.66 m (208 ft 10 in), Wingspan: 60.3 m (197 ft 10 in), Height: 16.79 m (55 ft 1 in)"
+              "key": "Dimensions",
+              "value": "Length: 14.83 meters (48 ft 8 in), Wingspan: 22.86 meters (75 ft), Height: 5.75 meters (18 ft 10 in)"
           },            
           {
-              "key": "Names:",
-              "value": "Airbus 330, Airbus A330, A330"
+              "key": "Names",
+              "value": "C-23 Sherpa, C-23, Sherpa"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with winglets at the tips."
+              "key": "Wings",
+              "value": "High-mounted, straight wings with two turboprop engines."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two underwing-mounted turbofan engines."
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted under the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Long, wide-body fuselage with twin-aisle configuration for passengers."
+              "key": "Fuselage",
+              "value": "Boxy fuselage with a rear loading ramp for easy cargo transport."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail with a tall vertical stabilizer and a low-mounted horizontal stabilizer."
-          }         
+              "key": "Tail",
+              "value": "Twin vertical stabilizers mounted at the rear of the fuselage with a horizontal stabilizer connecting them."
+          }          
       ]
 	},
-    {
-	"key": "Airbus A340",
-	"altNames": ["Airbus 340", "A340"], 
-	"tags": ["Plane", "Jet", "Four Engines", "Wide-Body", "Commercial Aircraft", "Passenger Transport", "Long-Haul", "Cargo Transport"],
-	"hltag": ["NCR"],
+{
+	"key": "AN-26 Curl",
+	"altNames": ["AN-26", "Curl"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Airbus"
+              "key": "Manufacturer",
+              "value": "Antonov"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "France"
+              "key": "Country of Origin",
+              "value": "Soviet Union"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Boeing 777, Airbus A330"
+              "key": "Similar Aircraft",
+              "value": "Lockheed C-130 Hercules, Boeing 737"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Twin-engine turboprop transport aircraft known for its ruggedness and capability to operate from unpaved airstrips."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "Long-haul passenger transport"
+              "key": "Role",
+              "value": "Cargo Transport"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "Can be fitted with light weapons for support missions"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 75.36 m (247 ft 2 in), Wingspan: 63.45 m (208 ft 2 in), Height: 17.03 m (55 ft 10 in)"
+              "key": "Dimensions",
+              "value": "Length: 24.78 meters (81 ft 3 in), Wingspan: 29.70 meters (97 ft 5 in), Height: 8.1 meters (26 ft 7 in)"
           },            
           {
-              "key": "Names:",
-              "value": "Airbus 340, Airbus A340, A340"
+              "key": "Names",
+              "value": "AN-26 Curl, AN-26, Curl"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with winglets at the tips."
+              "key": "Wings",
+              "value": "High-mounted wings designed for excellent lift and performance."
           },
           {
-              "key": "Engine(s):",
-              "value": "Four underwing-mounted turbofan engines."
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted on the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Long, wide-body fuselage with twin-aisle configuration for passengers."
+              "key": "Fuselage",
+              "value": "Large fuselage designed for cargo capacity and versatility."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail with a tall vertical stabilizer and a low-mounted horizontal stabilizer."
-          }         
+              "key": "Tail",
+              "value": "Conventional tail configuration with a large vertical stabilizer."
+          }          
       ]
 	},
-    {
-	"key": "Boeing 737",
-	"altNames": ["B737"],
-	"tags": ["Plane", "Jet", "Twin Engines", "Narrow-Body", "Commercial Aircraft", "Passenger Transport", "Short-Haul", "Medium-Haul"],
-	"hltag": ["NCR"],
+{
+	"key": "AN-32 Cline",
+	"altNames": ["AN-32", "Cline"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
+              "key": "Manufacturer",
+              "value": "Antonov"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Soviet Union"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Lockheed C-130 Hercules, CASA C-295"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": " Twin-engine turboprop transport aircraft with a high-wing design and large cargo hold, suitable for rough terrain."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Cargo Transport"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with light weapons for support missions"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 24.85 meters (81 ft 6 in), Wingspan: 29.70 meters (97 ft 5 in), Height: 8.9 meters (29 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "AN-32 Cline, AN-32, Cline"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for stability and lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted on the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Rugged fuselage designed for cargo transport and operational versatility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "AH-1 Cobra",
+	"altNames": ["AH-1", "Cobra"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bell Helicopter"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "AH-64 Apache"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Narrow fuselage, tandem seating, and distinctive nose-mounted weapons."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Attack Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "20mm M197 Gatling gun, Hellfire missiles, Hydra 70 rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 16.2 meters (53 ft 2 in), Rotor Diameter: 13.4 meters (44 ft), Height: 4.1 meters (13 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "AH-1 Cobra, AH-1, Cobra"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Small, stubby wings with hardpoints for external ordnance, located below the rotor blades."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Narrow and sleek fuselage with tandem seating for the pilot and gunner."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted at the rear."
+          }          
+      ]
+	},
+{
+	"key": "AH-64 Apache",
+	"altNames": ["AH-64", "Apache"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
               "value": "Boeing"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "irbus A320, Boeing 757"
+              "key": "Similar Aircraft",
+              "value": "AH-1 Cobra, Mi-24 Hind, Ka-52 Hokum"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Tandem seating, heavily armored cockpit, and distinctive large, four-blade rotor system."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "Narrow-body commercial airliner for short to medium-haul passenger transport"
+              "key": "Role",
+              "value": "Attack Helicopter"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "30mm M230 Chain Gun, AGM-114 Hellfire missiles, Hydra 70 rockets"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 102 ft (31.09 m) to 138 ft, 2 in (42.1 m), Span: 117 ft, 5 in (35.8 m)"
+              "key": "Dimensions",
+              "value": "Length: 17.7 meters (58 ft), Rotor Diameter: 14.6 meters (48 ft), Height: 3.87 meters (12 ft 8 in)"
           },            
           {
-              "key": "Names:",
-              "value": "Boeing 737, B737" 
+              "key": "Names",
+              "value": "AH-64 Apache, AH-64, Apache"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and blended winglets on newer models."
+              "key": "Wings",
+              "value": "Small, stubby wings with hardpoints for external ordnance located below the rotor system."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted under the wings, with nacelles extending forward of the wings' leading edges."
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on the sides of the fuselage near the rotor mast."
           },
           {
-              "key": "Fuselage:",
-              "value": "Narrow cylindrical body with a rounded nose, single passenger aisle, and conventional pressurized cabin design."
+              "key": "Fuselage",
+              "value": "Narrow, armored fuselage with tandem seating for the pilot and co-pilot/gunner."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single vertical stabilizer and low-mounted horizontal stabilizers."
-          }         
-      ]
-	},
-    {
-	"key": "Boeing 747",
-	"altNames": ["B747"],
-	"tags": ["Plane", "Jet", "Four Engines", "Wide-Body", "Commercial Aircraft", "Passenger Transport", "Cargo Transport", "Long-Haul", "VIP Transport"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Boeing"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "A340, AN-124 Condor"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Wide-body commercial airliner for long-haul passenger and cargo transport. Boeing 747-200B (VC-25A) is used as Air Force 1"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 231 ft, 10 in (70.66 m), Span: 224 ft, 7 in (68.4 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Boeing 747, B747"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with a wide chord, slight taper, and winglets."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Four turbofan engines mounted under the wings, with nacelles evenly spaced along the wings' leading edges."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Wide, cylindrical body with a distinctive hump on the upper forward fuselage that houses the cockpit and additional seating or cargo space."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail design with a large single vertical stabilizer and low-mounted horizontal stabilizers."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the side at the rear of the fuselage."
           }          
       ]
 	},
-    {
-	"key": "Boeing 757",
-	"altNames": ["B757"],
-	"tags": ["Plane", "Jet", "Twin Engines", "Narrow-Body", "Commercial Aircraft", "Passenger Transport", "Cargo Transport", "Short-Haul", "Medium-Haul"],
-	"hltag": ["NCR"],
+{
+	"key": "Ka-50/52 Hokum A/B",
+	"altNames": ["Ka-50 Hokum A", "Ka-52 Hokum B", "Ka-50A", "Ka-50", "Ka-52", "Ka-52B", "Hokum"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Boeing"
+              "key": "Manufacturer",
+              "value": "Kamov"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "Russia"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Boeing 737, Airbus A320"
+              "key": "Similar Aircraft",
+              "value": "Mi-28 Havoc, AH-64 Apache, Mi-24 Hind"
               
           },
           {
-              "key": "Crew:",
-              "value": "Two"
+              "key": "Distinctive Features",
+              "value": "Coaxial rotor system, single-seat (Ka-50) or tandem-seat (Ka-52) cockpit, and heavily armored fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One (Ka-50), Two (Ka-52)"
           },
           {
-              "key": "Role:",
-              "value": "Narrow-body commercial airliner for short to medium-haul passenger and cargo transport"
+              "key": "Role",
+              "value": "Attack Helicopter"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "30mm 2A42 autocannon, Vikhr anti-tank missiles, rockets, bombs"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 155 ft, 3 in (47.32 m), Span: 124 ft, 10 in (38.05 m)"
+              "key": "Dimensions",
+              "value": "Length: 16 meters (52 ft 6 in), Rotor Diameter: 14.5 meters (47 ft 7 in), Height: 4.9 meters (16 ft 1 in)"
           },            
           {
-              "key": "Names:",
-              "value": "Boeing 757, B757"
+              "key": "Names",
+              "value": "Ka-50 Hokum A, Ka-52 Hokum B, Ka-50A, Ka-52B Hokum"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with a slight taper and blended winglets on some models."
+              "key": "Wings",
+              "value": "Small, stubby wings with external hardpoints for carrying ordnance."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted under the wings, with nacelles extending forward of the wings' leading edges."
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on the sides of the fuselage, powering the coaxial rotor system."
           },
           {
-              "key": "Fuselage:",
-              "value": "Narrow cylindrical body with a pointed nose, single passenger aisle, and conventional pressurized cabin design."
+              "key": "Fuselage",
+              "value": "Heavily armored fuselage with a streamlined, narrow profile and tandem seating in the Ka-52."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single vertical stabilizer and low-mounted horizontal stabilizers."
+              "key": "Tail",
+              "value": "No tail rotor due to the coaxial rotor configuration; features a small vertical stabilizer at the rear of the fuselage."
           }          
       ]
 	},
-    {
-	"key": "Boeing 767",
-	"altNames": ["B767"], 
-	"tags": ["Plane", "Jet", "Twin Engines", "Wide-Body", "Commercial Aircraft", "Passenger Transport", "Cargo Transport", "Medium-Haul", "Long-Haul"],
-	"hltag": ["NCR"],
+{
+	"key": "Mi-24 Hind",
+	"altNames": ["Mi-24", "Hind"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Boeing"
+              "key": "Manufacturer",
+              "value": "Mil"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "Russia"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Airbus A300, Boeing 777"
+              "key": "Similar Aircraft",
+              "value": "Mi-28 Havoc, AH-64 Apache, Ka-50 Hokum"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Tandem cockpit with a heavily armed and armored fuselage, large cabin capable of carrying troops."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "Wide-body commercial airliner for medium to long-haul passenger and cargo transport"
+              "key": "Role",
+              "value": "Attack Helicopter / Transport"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "30mm autocannon or 12.7mm machine gun, anti-tank missiles, rockets, bombs"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 159 ft, 2 in (48.51 m) to 201 ft, 4 in (61.37 m), Span: 156 ft, 1 in (47.57 m)"
+              "key": "Dimensions",
+              "value": "Length: 17.5 meters (57 ft 5 in), Rotor Diameter: 17.3 meters (56 ft 9 in), Height: 6.5 meters (21 ft 4 in)"
           },            
           {
-              "key": "Names:",
-              "value": "Boeing 767, B767"
+              "key": "Names",
+              "value": "Mi-24 Hind, Mi-24, Hind"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and winglets on newer models."
+              "key": "Wings",
+              "value": "Mid-mounted wings with multiple hardpoints for carrying external ordnance, located below the rotor system."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted under the wings, with nacelles extending forward of the wings' leading edges."
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on the top of the fuselage, powering the rotor system."
           },
           {
-              "key": "Fuselage:",
-              "value": "Wide, cylindrical body with a rounded nose, two passenger aisles, and a conventional pressurized cabin design."
+              "key": "Fuselage",
+              "value": "Heavily armored fuselage with tandem seating in the cockpit and a large cabin capable of transporting troops or equipment."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single vertical stabilizer and low-mounted horizontal stabilizers."
-          }         
-      ]
-	},
-    {
-	"key": "Boeing 777",
-	"altNames": ["B777"], 
-	"tags": ["Plane", "Jet", "Twin Engines", "Wide-Body", "Commercial Aircraft", "Passenger Transport", "Cargo Transport", "Long-Haul", "High-Capacity"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Boeing"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Boeing 767, Airbus A330"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Wide-body commercial airliner for long-haul passenger and cargo transport."
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 209 ft, 1 in (63.7 m) to 242 ft, 4 in (73.86 m), Span: 199 ft, 11 in (60.9 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Boeing 777, B777"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with a wide chord, slight taper, and raked wingtips on newer models."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two large turbofan engines mounted under the wings, with nacelles extending forward of the wings' leading edges."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Wide, cylindrical body with a rounded nose, two passenger aisles, and a conventional pressurized cabin design."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single vertical stabilizer and low-mounted horizontal stabilizers."
-          }         
-      ]
-	},
-    {
-	"key": "Boeing 787",
-	"altNames": ["B787"],
-	"tags": ["Plane", "Jet", "Twin Engines", "Wide-Body", "Commercial Aircraft", "Passenger Transport", "Cargo Transport", "Long-Haul", "High-Capacity", "Fuel Efficient"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Boeing"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Boeing 767, Boeing 777"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Wide-body commercial airliner for long-haul passenger transport."
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 186 ft, 1 in (56.72 m) to 224 ft (68.28 m), Span: 197 ft, 3 in (60.12 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Boeing 787, B787"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with a significant taper and curved, flexible wingtips."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two large turbofan engines mounted under the wings, with nacelles extending forward of the wings' leading edges."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Wide, cylindrical body made of composite materials, with a rounded nose and two passenger aisles."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single vertical stabilizer and low-mounted horizontal stabilizers."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side of the rear fuselage."
           }          
       ]
 	},
-    {
-	"key": "Challenger",
-	"altNames": [""],
-	"tags": ["Plane", "Jet", "Twin Engines", "Business Jet", "Corporate Transport", "VIP Transport", "Private Jet", "Luxury Aircraft", "Executive Jet", "Medium-Range"],
-	"hltag": ["NCR"],
+{
+	"key": "Mi-28 Havoc",
+	"altNames": ["Mi-28", "Havoc"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Bombardier Aerospace"
+              "key": "Manufacturer",
+              "value": "Mil"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "Canada"
+              "key": "Country of Origin",
+              "value": "Russia"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Gulfstream, Hawker 800"
+              "key": "Similar Aircraft",
+              "value": "AH-64 Apache, Ka-50 Hokum, Mi-24 Hind"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Tandem cockpit with a heavily armored fuselage, large chin-mounted cannon, and four-blade rotor system."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "Business jet for corporate, VIP transport, and military use"
+              "key": "Role",
+              "value": "Attack Helicopter"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "30mm Shipunov 2A42 autocannon, anti-tank guided missiles, rockets, bombs"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 68 ft, 5 in (20.85 m), Span: 64 ft, 4 in (19.61 m)"
+              "key": "Dimensions",
+              "value": "Length: 17.01 meters (55 ft 10 in), Rotor Diameter: 17.20 meters (56 ft 5 in), Height: 3.82 meters (12 ft 6 in)"
           },            
           {
-              "key": "Names:",
-              "value": "Challenger"
+              "key": "Names",
+              "value": "Mi-28 Havoc, Mi-28, Havoc"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and winglets."
+              "key": "Wings",
+              "value": "Small, stubby wings with multiple hardpoints for external ordnance, located below the rotor system."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted at the rear fuselage, extending beyond the tail section."
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on the sides of the fuselage, powering the rotor system."
           },
           {
-              "key": "Fuselage:",
-              "value": "Streamlined, cylindrical fuselage with a pointed nose and large windows for passenger comfort."
+              "key": "Fuselage",
+              "value": "Heavily armored fuselage with tandem seating for the pilot and gunner in the cockpit."
           },     
           {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single vertical stabilizer and high-mounted horizontal stabilizers."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side at the rear of the fuselage."
           }          
       ]
 	},
-    {
-	"key": "Cessna 500 Citation",
-	"altNames": ["Cessna 500", "Citation"],
-	"tags": ["Plane", "Jet", "Twin Engines", "Business Jet", "Corporate Transport", "VIP Transport", "Private Jet", "Executive Jet", "Light Jet", "Short-Range"],
-	"hltag": ["NCR"],
+{
+	"key": "A129 Mangusta",
+	"altNames": ["A129", "Mangusta"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Cessna"
+              "key": "Manufacturer",
+              "value": "Agusta"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Lear Jet, Hawker 800"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Business jet for corporate, VIP transport, and utility use."
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 48 ft, 11 in (14.91 m), Span: 54 ft, 10 in (16.71 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Cessna 500 Citation, Cessna 500, Citation"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and winglets on some models."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted at the rear fuselage."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Streamlined cylindrical body with a pointed nose, featuring large windows for passenger comfort."
-          },     
-          {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single vertical stabilizer and high-mounted horizontal stabilizers."
-          }          
-      ]
-	},
-    {
-	"key": "CRJ",
-	"altNames": ["CRJ-100"], 
-	"tags": ["Plane", "Jet", "Twin Engines", "Regional Jet", "Passenger Jet", "Short-Haul", "Commercial Transport", "Civil Aviation", "Airliner", "Jet Airliner"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Bombardier Aerospace"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "Canada"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "ERJ-145,Challenger"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Regional jet for short to medium-haul passenger transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 87 ft, 10 in (26.77 m), Span: 69 ft, 7 in (21.21 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "CRJ"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and winglets on some models."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted at the rear of the fuselage, near the tail."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Long, cylindrical body with a pointed nose, designed to accommodate multiple rows of passengers in a single aisle configuration."
-          },     
-          {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single vertical stabilizer and high-mounted horizontal stabilizers."
-          }         
-      ]
-	},
-    {
-	"key": "Dassault Falcon 50",
-	"altNames": [""], 
-	"tags": ["Plane", "Jet", "Triple Engines", "Business Jet", "Corporate Jet", "VIP Transport", "Executive Transport", "Private Jet", "Long-Range Jet", "Civil Aviation"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Dassault Aviation"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "France"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Gulfstream, Hawker 800, DC-10"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Business jet for corporate, VIP transport, and military use."
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 60 ft, 9 in (18.60 m), Span: 61 ft, 11 in (18.87 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Dassault Falcon 50"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and no winglets."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Three turbofan engines, two mounted at the rear fuselage sides, and one mounted at the rear centerline."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Streamlined and cylindrical, with a pointed nose and large windows for passenger comfort."
-          },     
-          {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single vertical stabilizer and high-mounted horizontal stabilizers."
-          }          
-      ]
-	},
-    {
-	"key": "DC-10",
-	"altNames": [""],
-	"tags": ["Plane", "Jet", "Three Engines", "Wide-Body", "Commercial Airliner", "Cargo Plane", "Passenger Transport", "Long-Haul", "Civil Aviation", "Heavy-Lift"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "McDonnell Douglas"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "MD-80, Dassault Flacon 50"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Three"
-          },
-          {
-              "key": "Role:",
-              "value": "Wide-body commercial airliner for long-haul passenger and cargo transport, also used in military applications such as aerial refueling (KC-10 variant)"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 182 ft, 1 in (55.5 m), Span: 155 ft, 4 in (47.3 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "DC-10"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with wide chord and slightly tapered tips, featuring small winglets on later models."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Three turbofan engines, two mounted under the wings and one mounted at the base of the vertical stabilizer (tail engine)."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Wide, cylindrical body with a rounded nose, designed for long-haul passenger or cargo transport."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single large vertical stabilizer, and the third engine mounted at its base, with low-mounted horizontal stabilizers."
-          }          
-      ]
-	},
-    {
-	"key": "ERJ-145",
-	"altNames": [""], 
-	"tags": ["Plane", "Jet", "Twin Engines", "Regional Jet", "Passenger Transport", "Short-Haul", "Civil Aviation", "Commercial Airliner"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Embraer"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "Brazil"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "CRJ, MD-80, Challenger"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Regional jet for short-haul passenger transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 98 ft (29.87 m), Span: 65 ft, 9 in (20.04 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "ERJ-145"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and no winglets."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted at the rear fuselage, close to the tail section."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Long, narrow cylindrical body with a pointed nose and single-aisle passenger cabin."
-          },     
-          {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single vertical stabilizer and high-mounted horizontal stabilizers."
-          }          
-      ]
-	},
-    {
-	"key": "ERJ-170",
-	"altNames": [""],
-	"tags": ["Plane", "Jet", "Twin Engines", "Regional Jet", "Passenger Transport", "Short-Haul", "Civil Aviation", "Commercial Airliner"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Embraer"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "Brazil"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Airbus A300, Boeing 737"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Regional jet for short to medium-haul passenger transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 98 ft, 1 in (29.90 m), Span: 85 ft, 4 in (26.00 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "ERJ-170"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and winglets."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted under the wings."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Cylindrical fuselage with a slightly rounded nose, designed to accommodate passengers in a single-aisle configuration."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single vertical stabilizer and low-mounted horizontal stabilizers."
-          }         
-      ]
-	},
-    {
-	"key": "Gulf Stream",
-	"altNames": [""],
-	"tags": ["Plane", "Jet", "Twin Engines", "Business Jet", "Corporate Transport", "VIP Transport", "Executive Jet", "Long-Range"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Gulf Stream Aerospace"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Challenger"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Business jet for corporate, VIP transport, and military use"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 96 ft, 5 in (29.39 m), Span: 93 ft, 6 in (28.5 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Gulf Stream"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and winglets."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted at the rear fuselage."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Long, cylindrical body with a pointed nose and large windows for passenger comfort. A mnemonic device to remember this by is “Golf Ball Windows”, the windows are round like golf balls. It is the only fuselage mounted engine jet on this list that has round windows."
-          },     
-          {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single vertical stabilizer and high-mounted horizontal stabilizer."
-          }         
-      ]
-	},
-    {
-	"key": "Hawker 800",
-	"altNames": [""],
-	"tags": ["Plane", "Jet", "Twin Engines", "Business Jet", "Corporate Transport", "VIP Transport", "Executive Jet", "Mid-Range"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Hawker Beechcraft"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US/Uk"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Gulf Stream, Cessna 500 Citation, Lear Jet"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Business jet for corporate, VIP transport, and military use"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 51 ft, 2 in (15.60 m), Span: 54 ft, 4 in (16.54 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Hawker 800"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and winglets."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted at the rear fuselage."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Streamlined, cylindrical body with a pointed nose and large windows for passenger comfort."
-          },     
-          {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single vertical stabilizer and high-mounted horizontal stabilizers. A mnemonic device to remember this by “Hockey Stick Tail” because of the tail backwards slant it makes it look like the end of a hockey stick."
-          }         
-      ]
-	},
-    {
-	"key": "Lear Jet",
-	"altNames": [""],
-	"tags": ["Plane", "Jet", "Twin Engines", "Business Jet", "Corporate Transport", "VIP Transport", "Executive Jet", "High-Speed", "Light Jet"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Bombardier"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Gulf Stream, Cessna 500 Citation, Hawker 800"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Business jet for corporate, VIP transport, and military use"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 51 ft, 2 in (15.60 m), Span: 54 ft, 4 in (16.54 m)"
-          },           
-          {
-              "key": "Names:",
-              "value": "Lear Jet"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and winglets."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted at the rear fuselage."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Streamlined, cylindrical body with a pointed nose and large windows for passenger comfort."
-          },     
-          {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single vertical stabilizer and high-mounted horizontal stabilizers. "
-          }         
-      ]
-	},
-    {
-	"key": "MD-80",
-	"altNames": [""],
-	"tags": ["Plane", "Jet", "Twin Engines", "Commercial Airliner", "Narrow-Body", "Medium-Range", "Passenger Transport", "Short-Haul"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "McDonnell Douglas"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "ERJ-145"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Narrow-body commercial airliner for short to medium-haul passenger transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "147 ft, 10 in (45.06 m), Span: 107 ft, 10 in (32.8 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "MD-80"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and no winglets."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turbofan engines mounted at the rear fuselage, near the tail."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Long, cylindrical body with a pointed nose and a single passenger aisle."
-          },     
-          {
-              "key": "Tail:",
-              "value": "T-tail configuration with a single vertical stabilizer and high-mounted horizontal stabilizers. A mnemonic device to remember this by “80 Windows” it looks like there are a lot of windows. It does not actually have 80 windows but there are a lot of windows."
-          }          
-      ]
-	},
-    {
-	"key": "UH-60 Blackhawk",
-	"altNames": ["UH-60", "Blackhawk"], 
-	"tags": ["Helicopter", "Twin Engines", "Utility Helicopter", "Military", "Transport", "Rescue", "Troop Transport", "Medical Evacuation", "Search and Rescue", "Air Assault"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Sikorsky"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "UH-72 Lakota, CH-53 Sea Stallion"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Military utility helicopter for troop transport, medical evacuation, and cargo transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "Can be equipped with door-mounted machine guns (e.g., M240, GAU-17), and various external weapons systems"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 64 ft, 10 in (19.76 m), Rotor Diameter: 53 ft, 8 in (16.36 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "UH-60 Blackhawk, UH-60, Blackhawk"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings, but equipped with two stub wings or external pylons for mounting weapons or auxiliary fuel tanks."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turboshaft engines mounted above and behind the cockpit, with large intakes on either side of the fuselage."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Large, sleek fuselage with a slightly rounded nose, featuring a spacious cabin for personnel or cargo."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail boom with a single vertical stabilizer and a tail rotor mounted on the right side. Horizontal stabilizers are mounted midway down the tail boom."
-          }          
-      ]
-	},
-    {
-	"key": "BO-105",
-	"altNames": [""],
-	"tags": ["Helicopter", "Twin Engines", "Light Utility", "Military", "Civilian", "Medical Evacuation", "Law Enforcement", "Scout", "Anti-Tank", "Attack Helicopter"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Messerschmitt-Bölkow-Blohm "
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "Germany"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Bell 206, EC-135"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Light utility helicopter for reconnaissance, transport, and light attack roles"
-          },
-          {
-              "key": "Armament:",
-              "value": "Can be equipped with machine guns, rocket pods, or anti-tank missiles in military configurations"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 39 ft, 5 in (12.02 m), Rotor Diameter: 32 ft, 3 in (9.84 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "BO-105"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings; designed with a compact frame and no external pylons."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turboshaft engines mounted above the fuselage, behind the cockpit, with visible exhausts at the top."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Short and compact with a boxy, angular design, and a large bubble canopy for excellent visibility."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail boom with a single vertical stabilizer and a two-blade tail rotor mounted on the left side."
-          }          
-      ]
-	},
-    {
-	"key": "MD-500 Defender",
-	"altNames": ["MD-500", "Defender 500"],
-	"tags": ["Helicopter", "Single Engine", "Light Utility", "Military", "Scout", "Attack Helicopter", "Reconnaissance", "Armed Reconnaissance", "Anti-Tank", "Law Enforcement"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "McDonnell Douglas"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Aircraft: Bell 206, OH-58 Kiowa"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "One or two, depending on configuration"
-          },
-          {
-              "key": "Role:",
-              "value": "Light utility and observation helicopter, also used for light attack and reconnaissance"
-          },
-          {
-              "key": "Armament:",
-              "value": "Can be equipped with machine guns, rockets, or anti-tank missiles in military configurations"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 30 ft, 10 in (9.4 m), Rotor Diameter: 27 ft, 4 in (8.33 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "MD-500 Defender, MD-500, Defender 500"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings; compact frame with minimal external attachments."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "One turboshaft engine mounted above and behind the passenger compartment, with exhaust directed to the rear."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Small, rounded fuselage with a bubble canopy for high visibility, and a sleek, aerodynamic body."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail boom with a single vertical stabilizer and two-blade tail rotor mounted on the left side. Horizontal stabilizer is mounted near the base of the vertical fin."
-          }          
-      ]
-	},
-    {
-	"key": "HH-65 Dolphin",
-	"altNames": ["HH-65 Dolphin II", "HH-65", "Dolphin", "Dolphin II"], 
-	"tags": ["Helicopter", "Twin Engine", "Search and Rescue", "SAR", "Maritime Patrol", "Utility Helicopter", "Coast Guard", "Law Enforcement", "Medical Evacuation", "Enclosed Tail Rotor"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Airbus Helicopters"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "France"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "EC-135, AS-350 Squirrel"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two (pilot and co-pilot), plus additional crew for search and rescue or other missions"
-          },
-          {
-              "key": "Role:",
-              "value": "Search and rescue, law enforcement, and maritime patrol helicopter"
-          },
-          {
-              "key": "Armament:",
-              "value": "Typically none, but can be equipped with machine guns in some configurations"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 44 ft, 5 in (13.54 m), Rotor Diameter: 39 ft, 2 in (11.93 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "HH-65 Dolphin, HH-65, Dolphin, Dolphin II"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings; sleek, compact design for agility in maritime operations."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turboshaft engines mounted on top of the fuselage, behind the cockpit, with side-facing exhausts."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Streamlined and aerodynamic fuselage with a slightly rounded nose, featuring a large glass canopy for excellent visibility."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Fenestron enclosed tail rotor with a single vertical stabilizer and a small horizontal stabilizer located midway along the tail boom."
-          }          
-      ]
-	},
-    {
-	"key": "EC-120",
-	"altNames": ["EC-120 Colibri", "Colibri"],
-	"tags": ["Helicopter", "Single Engine", "Light Utility", "Training", "Private Transport", "Law Enforcement", "Enclosed Tail Rotor"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Airbus Helicopters"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "France"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "EC-135, HH-65"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "Light utility helicopter for training, law enforcement, and civilian transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "Typically none, but can be modified for light military roles"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 31 ft, 5 in (9.6 m), Rotor Diameter: 35 ft, 1 in (10.7 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "EC-120"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings; compact design for light utility use."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "One turboshaft engine mounted above and behind the passenger cabin, with exhaust directed toward the rear."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Small, sleek fuselage with a rounded nose and large windows, providing excellent visibility for pilot and passengers."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Fenestron enclosed tail rotor with a single vertical stabilizer and a small horizontal stabilizer mounted midway along the tail boom."
-          }          
-      ]
-	},
-    {
-	"key": "EC-135",
-	"altNames": [""],
-	"tags": ["Helicopter", "Twin Engines", "Light Utility", "Medical Evacuation", "Law Enforcement", "Corporate Transport", "Enclosed Tail Rotor"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Airbus Helicopters"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "France/ Germany"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "HH-65 Dolphin, EC-120"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Light utility helicopter for law enforcement, emergency medical services (EMS), and military transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "Typically none in civilian configurations, but military variants may be equipped with light armament"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 33 ft, 10 in (10.2 m), Rotor Diameter: 35 ft (10.69 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "EC-135"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings; compact and streamlined design optimized for maneuverability."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turboshaft engines mounted on top of the fuselage, behind the cockpit, with side-facing exhausts."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Sleek, rounded fuselage with a slightly pointed nose and large windows, designed for visibility and utility."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Fenestron enclosed tail rotor with a single vertical stabilizer and a small horizontal stabilizer mounted midway along the tail boom."
-          }          
-      ]
-	},
-    {
-	"key": "Bell 206 Jet Ranger",
-	"altNames": ["Bell 206", "Jet Ranger"],
-	"tags": ["Helicopter", "Single Engine", "Light Utility", "Private Transport", "Law Enforcement", "Training"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Bell Helicopters"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Bell 412, OH-58 Kiowa"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "Light utility and observation helicopter, also used for civilian transport and law enforcement."
-          },
-          {
-              "key": "Armament:",
-              "value": "Typically none in civilian versions; military versions (OH-58 Kiowa) can be equipped with machine guns or rockets."
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 39 ft, 8 in (12.12 m), Rotor Diameter: 33 ft, 4 in (10.16 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Bell 206 Jet Ranger, Bell 206, Jet Ranger"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings; compact, streamlined design with minimal external attachments."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "One turboshaft engine mounted above and behind the passenger cabin, with exhaust directed to the rear."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Small, sleek fuselage with a pointed nose and large, bubble-shaped canopy for excellent visibility."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail boom with a single vertical stabilizer and a two-blade tail rotor mounted on the right side. Horizontal stabilizer mounted near the base of the vertical fin."
-          }          
-      ]
-	},
-    {
-	"key": "Bell 412",
-	"altNames": [""],
-	"tags": ["Helicopter", "Twin Engines", "Utility", "Law Enforcement", "Search and Rescue", "Corporate Transport", "Military Transport"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Bell Helicopters"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "UH-1 Huey, Bell 206"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Medium utility helicopter for transport, search and rescue, law enforcement, and military operations"
-          },
-          {
-              "key": "Armament:",
-              "value": "Typically none in civilian versions; military variants can be equipped with machine guns, rockets, or other armament"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 56 ft, 2 in (17.12 m), Rotor Diameter: 46 ft, 0 in (14.02 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "Bell 412"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings; designed with external hardpoints or pylons for optional mission equipment."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turboshaft engines mounted above the fuselage, with exhausts directed to the rear."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Medium-sized fuselage with a rounded nose and a large cabin area, designed to carry passengers or cargo."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail boom with a single vertical stabilizer and a two-blade tail rotor mounted on the left side. Horizontal stabilizer is mounted near the base of the vertical fin."
-          }          
-      ]
-	},
-    {
-	"key": "UH-72 Lakota",
-	"altNames": ["UH-72", "Lakota"],
-	"tags": ["Helicopter", "Twin Engines", "Utility", "Medical Evacuation", "Law Enforcement", "Military Transport", "Search and Rescue"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Airbus Helicopter"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US (manufactured by Airbus Helicopters under license)"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": "Bell 412, EC-135"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "Two"
-          },
-          {
-              "key": "Role:",
-              "value": "Light utility helicopter for medical evacuation (MEDEVAC), search and rescue, law enforcement, and military transport"
-          },
-          {
-              "key": "Armament:",
-              "value": "Typically none, but can be equipped with machine guns in military configurations"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 42 ft, 8 in (13.0 m), Rotor Diameter: 36 ft, 1 in (11.00 m)"
-          },            
-          {
-              "key": "Names:",
-              "value": "UH-72 Lakota, UH-72, Lakota"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings; the helicopter has a streamlined, compact design with no visible external weapon or equipment mounts."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turboshaft engines mounted above the fuselage, with exhausts pointing rearward. The engine nacelles are integrated into the sleek body structure."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "The fuselage is rounded and sleek with a large bubble canopy and wide cabin, featuring square windows for excellent visibility and access. The cockpit has a sharply pointed nose, and the cabin is accessible through sliding side doors."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail boom with an exposed two-blade tail rotor mounted on the right side. The vertical stabilizer is angular and pointed, with a small horizontal stabilizer located midway along the tail boom."
-          }          
-      ]
-	},
-    {
-	"key": "AW-109 Power",
-	"altNames": [""],
-	"tags": ["Helicopter", "Twin Engines", "Utility", "Law Enforcement", "Search and Rescue", "Corporate Transport", "Military Transport", "Light Transport"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Agusta Westland"
-          },  
-          {
-              "key": "Country of Origin:",
+              "key": "Country of Origin",
               "value": "Italy"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Bell 412, EC-135"
+              "key": "Similar Aircraft",
+              "value": "AH-1 Cobra, AH-64 Apache"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Narrow fuselage, tandem seating, and distinctive nose-mounted weaponry."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "Light utility helicopter for military, law enforcement, medical evacuation (MEDEVAC), and VIP transport"
+              "key": "Role",
+              "value": "Attack Helicopter"
           },
           {
-              "key": "Armament:",
-              "value": "Typically none in civilian configurations, but can be equipped with machine guns or rocket pods in military "
+              "key": "Armament",
+              "value": "20mm cannon, anti-tank missiles, rockets"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 42 ft, 9 in (13.03 m), Rotor Diameter: 36 ft, 1 in (11.00 m)"
-          },           
-          {
-              "key": "Names:",
-              "value": "AW-109 Power"
-          }                      
-      ],
-      "weftDescription": [
-          {
-              "key": "Wings:",
-              "value": "No fixed wings; the helicopter has a streamlined, compact design optimized for light utility operations, without external hardpoints."
-          },
-          {
-              "key": "Engine(s):",
-              "value": "Two turboshaft engines mounted above the fuselage, with side-facing exhausts just behind the cockpit."
-          },
-          {
-              "key": "Fuselage:",
-              "value": "Sleek and narrow fuselage with a pointed nose, large rectangular windows, and a compact body design. The aircraft features retractable landing gear, providing a streamlined appearance."
-          },     
-          {
-              "key": "Tail:",
-              "value": "Conventional tail boom with a two-blade tail rotor mounted on the right side. The tail also features a distinctive single vertical stabilizer with a small horizontal stabilizer mounted near the base."
-          }          
-      ]
-	},
-    {
-	"key": "Robinson R-44 Raven",
-	"altNames": ["R-44", "Raven II", "Raven", "Robinson 44", "R-44 Raven","Robinson R-44 Raven II"],
-	"tags": ["Helicopter", "Single Engine", "Utility", "Private Transport", "Training", "Law Enforcement", "Light Utility"],
-	"hltag": ["NCR"],
-	"generalData": [
-          {
-              "key": "Manufacturer:",
-              "value": "Robinson Helicopter"
-          },  
-          {
-              "key": "Country of Origin:",
-              "value": "US"
-          },
-          {
-              "key": "Similar Aircraft:",
-              "value": " Bell 206, MD-500"
-              
-          },
-          {
-              "key": "Crew:",
-              "value": "One"
-          },
-          {
-              "key": "Role:",
-              "value": "Light utility helicopter for civilian transport, training, law enforcement, and aerial photography"
-          },
-          {
-              "key": "Armament:",
-              "value": "NONE"
-          }, 
-          {
-              "key": "Dimensions:",
-              "value": "Length: 38 ft, 3 in (11.66 m), Rotor Diameter: 33 ft (10.06 m)"
+              "key": "Dimensions",
+              "value": "Length: 12.28 meters (40 ft 3 in), Rotor Diameter: 11.9 meters (39 ft), Height: 3.35 meters (11 ft)"
           },            
           {
-              "key": "Names:",
-              "value": "R-44 Raven, R-44, Raven II"
+              "key": "Names",
+              "value": "A129 Mangusta, A129, Mangusta"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "No fixed wings; compact and streamlined with skid-type landing gear."
+              "key": "Wings",
+              "value": "Small, stubby wings with external hardpoints for ordnance."
           },
           {
-              "key": "Engine(s):",
-              "value": "One piston engine mounted at the rear of the cabin, with exhaust directed to the rear."
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted above the fuselage."
           },
           {
-              "key": "Fuselage:",
-              "value": "Small and cylindrical fuselage with a large bubble canopy, providing excellent visibility for the pilot and passengers. The cabin is compact with space for four occupants."
+              "key": "Fuselage",
+              "value": "Narrow fuselage with tandem seating for the pilot and gunner."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail boom with a small, two-blade tail rotor mounted on the left side. The tail also features a single vertical stabilizer and no horizontal stabilizers, contributing to the lightweight, minimalist design."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted at the rear of the fuselage."
           }          
       ]
 	},
-    {
-	"key": "VH-3 Sea King",
-	"altNames": ["VH-3", "Sea King"], 
-	"tags": ["Helicopter", "Twin Engine", "Utility", "Transport", "Presidential Transport", "VIP Transport", "Search and Rescue", "Anti-Submarine Warfare"],
-	"hltag": ["NCR"],
+{
+	"key": "Ec-665 Tiger",
+	"altNames": ["Ec-665", "Tiger"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Sikorsky"
+              "key": "Manufacturer",
+              "value": "Eurocopter"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "France / Germany"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "CH-53 Sea Stallion, UH-60 Blackhawk, VH-92 Patriot"
+              "key": "Similar Aircraft",
+              "value": "A129 Mangusta, AH-64 Apache"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Tandem seating, narrow fuselage, and a four-blade main rotor system."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "VIP transport helicopter, primarily used for transporting the President of the United States (Marine One)"
+              "key": "Role",
+              "value": "Attack Helicopter"
           },
           {
-              "key": "Armament:",
-              "value": "Typically none, but can be equipped with defensive countermeasures in military configurations"
-          },
+              "key": "Armament",
+              "value": "30mm autocannon, air-to-ground missiles, rockets"
+          }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 73 ft, 10 in (22.50 m), Rotor Diameter: 62 ft (18.90 m)"
+              "key": "Dimensions",
+              "value": "Length: 14.08 meters (46 ft 2 in), Rotor Diameter: 13.00 meters (42 ft 8 in), Height: 3.83 meters (12 ft 7 in)"
           },            
           {
-              "key": "Names:",
-              "value": "VH-3 Sea King, VH-3, Sea King"
+              "key": "Names",
+              "value": "Ec-665 Tiger, Ec-665, Tiger"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "No fixed wings; however, it features sponsons on both sides of the fuselage for housing landing gear and auxiliary fuel."
+              "key": "Wings",
+              "value": "Small, stubby wings with external hardpoints for ordnance."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turboshaft engines mounted above the fuselage near the rear of the cockpit, with exhausts directed to the rear."
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted above the fuselage near the rotor mast."
           },
           {
-              "key": "Fuselage:",
-              "value": "Large, boxy fuselage with a rounded nose and expansive cabin space, featuring numerous windows and side doors for easy access."
+              "key": "Fuselage",
+              "value": "Narrow, streamlined fuselage with tandem seating for the pilot and gunner."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail boom with a five-blade tail rotor mounted on the left side. The tail also features a vertical stabilizer with a slightly angled horizontal stabilizer mounted near the base of the tail boom."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear of the fuselage."
           }          
       ]
 	},
-    {
+{
+	"key": "CH-47 Chinook",
+	"altNames": ["CH-47", "Chinook"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "CH-46 Sea Knight"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-rotor design with no tail rotor, tandem rotor configuration, and rear loading ramp. It has 4 fixed Wheels on the bottom."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Three"
+          },
+          {
+              "key": "Role",
+              "value": "Heavy-Lift Transport Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns for self-defense"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 30.14 meters (98 ft 10 in), Rotor Diameter: 18.29 meters (60 ft), Height: 5.68 meters (18 ft 8 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "CH-47 Chinook, CH-47, Chinook"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features two large tandem rotors for lift, one on the front and one on the rear of the fuselage."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on the rear fuselage, powering the tandem rotors."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long, cylindrical fuselage with a rear ramp for loading and unloading cargo."
+          },     
+          {
+              "key": "Tail",
+              "value": "No tail rotor due to the tandem rotor configuration."
+          }          
+      ]
+	},
+{
 	"key": "CH-53 Sea Stallion",
-	"altNames": ["CH-53", "Sea Stallion"],
-	"tags": ["Helicopter", "Heavy-Lift", "Twin Engine", "Utility", "Cargo Transport", "Troop Transport", "Heavy Cargo", "Military", "Search and Rescue"],
+	"altNames": ["CH-53", "Sea Stallion"], 
+	"tags": [],
 	"hltag": ["NCR"],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Sikorsky"
+              "key": "Manufacturer",
+              "value": "Sikorsky Aircraft"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "VH-3 Sea King, UH-60 Blackhawk"
+              "key": "Similar Aircraft",
+              "value": "CH-47 Chinook"
               
           },
           {
-              "key": "Crew:",
-              "value": "Two"
+              "key": "Distinctive Features",
+              "value": "Large, heavy-lift helicopter with a six or seven-blade main rotor and a distinctive tail rotor."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Five"
           },
           {
-              "key": "Role:",
-              "value": "Heavy-lift cargo helicopter for transport, troop deployment, and equipment hauling"
+              "key": "Role",
+              "value": "Heavy-Lift Transport Helicopter"
           },
           {
-              "key": "Armament:",
-              "value": "Can be equipped with door-mounted machine guns (GAU-21 or M240)"
+              "key": "Armament",
+              "value": "Can be fitted with machine guns for self-defense"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 99 ft, 0 in (30.18 m), Rotor Diameter: 79 ft (24.08 m)"
+              "key": "Dimensions",
+              "value": "Length: 30.18 meters (99 ft), Rotor Diameter: 22.02 meters (72 ft 3 in), Height: 7.60 meters (24 ft 11 in)"
           },            
           {
-              "key": "Names:",
+              "key": "Names",
               "value": "CH-53 Sea Stallion, CH-53, Sea Stallion"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "No fixed wings; features large, sponson-like structures on both sides of the fuselage for auxiliary fuel tanks and landing gear."
+              "key": "Wings",
+              "value": "No wings; features a large, multi-blade main rotor for lift."
           },
           {
-              "key": "Engine(s):",
-              "value": "Three turboshaft engines mounted above the fuselage, with visible exhausts extending behind the engines."
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on top of the fuselage near the rotor system."
           },
           {
-              "key": "Fuselage:",
-              "value": "Large and bulky fuselage with a rounded nose and large rear ramp for cargo loading. The cabin is spacious, designed for carrying troops, vehicles, or cargo, with side access doors as well."
+              "key": "Fuselage",
+              "value": "Large, boxy fuselage with a rear loading ramp for transporting cargo and equipment."
           },     
           {
-              "key": "Tail:",
-              "value": "Extended tail boom with a four-blade tail rotor mounted on the left side. The tail features a vertical stabilizer with a pronounced horizontal stabilizer located near the base of the tail boom, as seen in the reference image."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a large tail rotor mounted on the right side of the rear fuselage."
           }          
       ]
 	},
-    {
-	"key": "AS-350 Squirrel",
-	"altNames": ["AS-350","Squirrel"],
-	"tags": ["Helicopter", "Light Utility", "Single Engine", "Civilian", "Private Transport", "Law Enforcement", "Medical Evacuation", "Search and Rescue"],
-	"hltag": ["NCR"],
+{
+	"key": "UH-60 Black Hawk",
+	"altNames": ["UH-60", "Black Hawk"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Airbus Helicopter"
+              "key": "Manufacturer",
+              "value": "Sikorsky Aircraft"
           },  
           {
-              "key": "Country of Origin:",
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "UH-1 Iroquois, SH-60 Seahawk"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Four-blade main rotor, sleek fuselage, and rear loading ramp."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rocket pods, or Hellfire missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 19.76 meters (64 ft 10 in), Rotor Diameter: 16.36 meters (53 ft 8 in), Height: 5.13 meters (16 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "UH-60 Black Hawk, UH-60, Black Hawk"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on top of the fuselage near the rotor system."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Sleek, streamlined fuselage with a large cabin capable of transporting troops or equipment, and a rear loading ramp."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "UH-72 Lakota",
+	"altNames": ["UH-72", "Lakota"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Airbus Helicopters"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States / France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "EC-145"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small, lightweight utility helicopter with twin engines and a traditional tail rotor (not enclosed)."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Reconnaissance Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 13.03 meters (42 ft 9 in), Rotor Diameter: 11.00 meters (36 ft 1 in), Height: 3.55 meters (11 ft 8 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "UH-72 Lakota, UH-72, Lakota"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on the top of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Small, streamlined fuselage with a large cabin for transporting passengers or equipment."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a conventional tail rotor mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "Mi-8 Hip",
+	"altNames": ["Mi-8", "Hip"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mil"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Mi-17"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Large utility helicopter with a five-blade main rotor and a large, boxy fuselage. Wheel well that runs down the length of the fuselage that makes it look like it has “Hips”"
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Three"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Transport Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rockets, or missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 18.17 meters (59 ft 7 in), Rotor Diameter: 21.29 meters (69 ft 10 in), Height: 5.65 meters (18 ft 7 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Mi-8 Hip, Mi-8, Hip"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a large five-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted above the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Large, boxy fuselage with a rear loading ramp for transporting troops or cargo."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the right side of the rear fuselage."
+          }          
+      ]
+	},
+{
+	"key": "Mi-26 Halo",
+	"altNames": ["Mi-26", "Halo"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mil"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "CH-53 Sea Stallion"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Largest and heaviest helicopter in the world with an eight-blade main rotor and massive fuselage. "
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Five"
+          },
+          {
+              "key": "Role",
+              "value": "Heavy-Lift Transport Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 40.03 meters (131 ft 4 in), Rotor Diameter: 32.00 meters (105 ft), Height: 8.15 meters (26 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "LMi-26 Halo, Mi-26, Halo"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a massive eight-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted above the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Very large fuselage with a rear loading ramp for heavy cargo transport."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a large tail rotor mounted on the left side of the rear fuselage."
+          }          
+      ]
+	},
+{
+	"key": "NH-90",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "NHIndustries"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France / Germany / Italy"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "AS332 Super Puma, SH-60 Seahawk"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Medium-sized utility helicopter with four-blade main rotor and streamlined fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Transport Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns and rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 16.13 meters (52 ft 11 in), Rotor Diameter: 16.3 meters (53 ft 6 in), Height: 5.23 meters (17 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "NH-90"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on top of the fuselage near the rotor mast."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Medium-sized, streamlined fuselage with a rear ramp for loading cargo or troops."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "SA-316/SA-319 Alouette III",
+	"altNames": ["SA-319 Alouette III", "SA-316 Alouette III", "SA-319", "SA-316", "Alouette III"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Aérospatiale"
+          },  
+          {
+              "key": "Country of Origin",
               "value": "France"
           },
           {
-              "key": "Similar Aircraft:",
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light utility helicopter with a three-blade main rotor and a slender fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rockets, or anti-tank missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 10.03 meters (32 ft 11 in), Rotor Diameter: 11.02 meters (36 ft 2 in), Height: 3.00 meters (9 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "SA-319 Alouette III, SA-316 Alouette III, SA-319, SA-316, Alouette III"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a three-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slender fuselage with a large glass cockpit and a small cabin for passengers or equipment."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "AS332/AS532 Super Puma/Cougar",
+	"altNames": ["AS332", "AS532", "AS332 Super Puma", "Super Puma", "AS532 Cougar", "Cougar"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Aérospatiale / Eurocopter"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "NH-90, SA-330 Puma"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Large utility helicopter with a four-blade main rotor and a distinctive high-mounted tail boom."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Transport Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rockets, or anti-tank missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 16.79 meters (55 ft 1 in), Rotor Diameter: 15.1 meters (49 ft 6 in), Height: 4.92 meters (16 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "AS332, AS532, AS332 Super Puma, Super Puma, AS532 Cougar, Cougar"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on top of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Large fuselage with a high-mounted tail boom and spacious cabin for troops or cargo."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side of the tail boom."
+          }          
+      ]
+	},
+{
+	"key": "SA-330 Puma",
+	"altNames": ["SA-330", "Puma"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Aérospatiale"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "AS332 Super Puma, NH-90"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Medium utility helicopter with a four-blade main rotor and high-mounted tail boom."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Transport Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rockets, or missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 18.15 meters (59 ft 7 in), Rotor Diameter: 15.10 meters (49 ft 6 in), Height: 5.14 meters (16 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "SA-330 Puma, SA-330, Puma"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on top of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Medium-sized fuselage with a high-mounted tail boom and a large cabin for transporting troops or equipment."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side of the tail boom."
+          }          
+      ]
+	},
+{
+	"key": "SH-3 Sea King",
+	"altNames": ["SH-3", "Sea King"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Sikorsky Aircraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "VH-3 Sea King"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Amphibious utility helicopter with a boat-shaped hull for water landings and five-blade main rotor."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Anti-Submarine Warfare (ASW)"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with torpedoes, depth charges, and machine guns"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 16.70 meters (54 ft 9 in), Rotor Diameter: 18.90 meters (62 ft), Height: 5.13 meters (16 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "SH-3 Sea King, SH-3, Sea King"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a five-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted above the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Boat-shaped hull for amphibious operations and large cabin for transporting troops or equipment."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "VH-3 Sea King",
+	"altNames": ["VH-3", "Sea King"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Sikorsky Aircraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "SH-3 Sea King"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "VIP transport variant of the SH-3 Sea King, used primarily for the transportation of high-ranking officials, including the U.S. president."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "VIP Transport"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 16.70 meters (54 ft 9 in), Rotor Diameter: 18.90 meters (62 ft), Height: 5.13 meters (16 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "VH-3 Sea King, VH-3, Sea King"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a five-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted above the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Boat-shaped hull with modifications for VIP transport, including enhanced interior accommodations."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "VH-92 Patriot",
+	"altNames": ["VH-92", "Patiot"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Sikorsky Aircraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "SH-60 Seahawk, UH-60 Black Hawk"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "VIP transport helicopter designed to replace the VH-3 Sea King for the transportation of high-ranking officials, including the U.S. president."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "VIP Transport"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 19.76 meters (64 ft 10 in), Rotor Diameter: 16.36 meters (53 ft 8 in), Height: 5.13 meters (16 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "VH-92 Patriot, VH-92, Patriot"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on top of the fuselage near the rotor system."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Sleek fuselage with modifications for VIP transport, including enhanced interior accommodations."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side of the rear fuselage."
+          }          
+      ]
+	},
+{
+	"key": "KA-27 Helix",
+	"altNames": ["KA-27", "Helix"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Kamov"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Coaxial rotor system (no tail rotor) and a boat-shaped fuselage designed for maritime operations."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Three"
+          },
+          {
+              "key": "Role",
+              "value": "Anti-Submarine Warfare (ASW) / Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with torpedoes, depth charges, and machine guns"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11.3 meters (37 ft 1 in), Rotor Diameter: 15.9 meters (52 ft 2 in), Height: 5.4 meters (17 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "KA-27 Helix, KA-27, Helix"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a coaxial rotor system (counter-rotating rotors) for lift, eliminating the need for a tail rotor."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted above the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Boat-shaped fuselage for maritime operations, with a small cabin for crew or equipment."
+          },     
+          {
+              "key": "Tail",
+              "value": "No tail rotor due to the coaxial rotor configuration; features a small vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "CH-46 Sea Knight",
+	"altNames": ["CH-46", "Sea Knight"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "CH-47 Chinook"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-rotor design with tandem rotors and a smaller fuselage compared to the Chinook. It has 3 fixed wheels on the bottom."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "Medium-Lift Transport Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns on either side of the fuselage"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 13.6 meters (44 ft 7 in), Rotor Diameter: 15.24 meters (50 ft), Height: 5.1 meters (16 ft 7 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "CH-46 Sea Knight, CH-46, Sea Knight"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features two tandem rotors for lift, one mounted on the front and one on the rear of the fuselage."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on the rear fuselage, powering the tandem rotors."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Medium-sized fuselage with a rear ramp for cargo or troop loading."
+          },     
+          {
+              "key": "Tail",
+              "value": "No tail rotor due to the tandem rotor configuration."
+          }          
+      ]
+	},
+{
+	"key": "SH-60 Seahawk",
+	"altNames": ["SH-60", "Seahawk"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Sikorsky Aircraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "UH-60 Black Hawk"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Four-blade main rotor, naval adaptations including folding rotor blades and tail for shipboard operations."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "Naval Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, Hellfire missiles, and torpedoes"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 19.76 meters (64 ft 10 in), Rotor Diameter: 16.36 meters (53 ft 8 in), Height: 5.13 meters (16 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "SH-60 Seahawk, SH-60, Seahawk"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift, with folding blades for shipboard operations."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted on top of the fuselage near the rotor system."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Sleek fuselage with naval adaptations, including a reinforced structure and a large cabin for transporting troops or equipment."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side, with a folding tail for shipboard storage."
+          }          
+      ]
+	},
+{
+	"key": "UH-1 Iroquois (Huey)",
+	"altNames": ["UH-1 Iroquois", "UH-1 Huey", "UH-1", "Iroquois", "Huey"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bell Helicopter"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "UH-60 Black Hawk, Bell 412"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Large, single main rotor and tail rotor, with a boxy fuselage and skids for landing."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rocket pods, or grenade launchers"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 17.40 meters (57 ft 1 in), Rotor Diameter: 14.63 meters (48 ft), Height: 4.42 meters (14 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "UH-1 Iroquois, UH-1, Iroquois, Huey"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": " No wings; features a large single main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Boxy fuselage with a large cabin capable of carrying troops or equipment, and skids for landing."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the left side at the rear."
+          }          
+      ]
+	},
+{
+	"key": "BO-105",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Messerschmitt-Bölkow-Blohm (MBB)"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Germany"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "EC-135, Bell 206"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light utility helicopter with a rigid rotor system and compact fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns and anti-tank missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11.86 meters (38 ft 11 in), Rotor Diameter: 9.84 meters (32 ft 3 in), Height: 3.00 meters (9 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "BO-105"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade rigid main rotor system for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted in the rear of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact and lightweight fuselage with a flat cabin floor for flexibility in light utility and recon missions."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "MD-500 Defender",
+	"altNames": ["MD-500", "Defender 500", "MD Defender 500 "], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "McDonnell Douglas"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "OH-6 Cayuse, AH-6 Little Bird"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small, agile helicopter with a compact fuselage and distinctive bubble canopy."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rockets, or anti-tank missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 9.40 meters (30 ft 10 in), Rotor Diameter: 8.00 meters (26 ft 3 in), Height: 2.85 meters (9 ft 4 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MD-500 Defender, MD-500, Defender 500, MD Defender 500 "
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a small, four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the rear of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage with a distinctive bubble canopy and flat floor for recon or light utility missions."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "OH-58 Kiowa",
+	"altNames": ["OH-58", "Kiowa"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bell Helicopter"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "OH-6 Cayuse, MD-500 Defender"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light reconnaissance helicopter with a distinctive mast-mounted sight above the rotor system."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rocket pods, or Hellfire missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 12.85 meters (42 ft 2 in), Rotor Diameter: 10.77 meters (35 ft 4 in), Height: 3.93 meters (12 ft 11 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "OH-58 Kiowa, OH-58, Kiowa"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a two-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted above the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact, lightweight fuselage with a distinctive mast-mounted sight above the rotor."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "OH-6A Cayuse",
+	"altNames": ["OH-6A", "Cayuse"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Hughes Helicopters"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MD-500 Defender, AH-6 Little Bird"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small, highly maneuverable helicopter with a compact, egg-shaped fuselage and bubble canopy."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rocket pods, or anti-tank missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 9.80 meters (32 ft 2 in), Rotor Diameter: 8.03 meters (26 ft 4 in), Height: 2.70 meters (8 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "OH-6A Cayuse, OH-6A, Cayuse"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the rear of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact, egg-shaped fuselage with a bubble canopy for high visibility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "Z-9 Harbin",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Harbin Aircraft Manufacturing Corporation"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "China"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "AS-365 Dauphin, HH-65 Dolphin"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Medium utility helicopter based on the AS-365 Dauphin, with a fenestron tail rotor."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Recon / Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, anti-tank missiles, or rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 13.45 meters (44 ft 2 in), Rotor Diameter: 11.93 meters (39 ft 2 in), Height: 3.93 meters (12 ft 11 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Z-9 Harbin" 
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted inside the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a spacious cabin for utility or recon missions."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a fenestron (enclosed) tail rotor."
+          }          
+      ]
+	},
+{
+	"key": "AS-350 Squirrel",
+	"altNames": ["AS-350", "Squirrel"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Aérospatiale"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
               "value": "Bell 206, EC-120"
               
           },
           {
-              "key": "Crew:",
-              "value": "One"
+              "key": "Distinctive Features",
+              "value": "Light utility helicopter with a single main rotor and a compact fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "Light utility helicopter for law enforcement, civilian transport, search and rescue, and aerial work"
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
           },
           {
-              "key": "Armament:",
-              "value": "Typically none in civilian versions; military variants can be equipped with machine guns and rockets"
+              "key": "Armament",
+              "value": "Can be fitted with machine guns and anti-tank missiles"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 42 ft, 4 in (12.9 m), Rotor Diameter: 35 ft, 1 in (10.7 m)"
+              "key": "Dimensions",
+              "value": "Length: 10.93 meters (35 ft 10 in), Rotor Diameter: 10.69 meters (35 ft 1 in), Height: 3.14 meters (10 ft 4 in)"
           },            
           {
-              "key": "Names:",
+              "key": "Names",
               "value": "AS-350 Squirrel, AS-350, Squirrel"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "No fixed wings; features skid-type landing gear for light utility and off-airfield operations."
+              "key": "Wings",
+              "value": " No wings; features a three-blade main rotor for lift."
           },
           {
-              "key": "Engine(s):",
-              "value": "One turboshaft engine mounted above the fuselage, with the exhaust extending toward the rear."
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the fuselage."
           },
           {
-              "key": "Fuselage:",
-              "value": "Streamlined, with a bubble-shaped canopy for the cockpit, providing excellent visibility for the pilot and passengers. The body is compact and slightly rounded, with side doors for passenger access."
+              "key": "Fuselage",
+              "value": "Compact fuselage with a bubble canopy for high visibility during reconnaissance missions."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail boom with two-bladed tail rotor mounted on the left side. The tail also features a vertical stabilizer with a small horizontal stabilizer near the base of the tail boom."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear of the fuselage."
           }          
       ]
 	},
-    {
-	"key": "VH-92 ",
-	"altNames": ["VH-92 Patriot", "Patriot", "Sikorsky"],
-	"tags": ["Helicopter", "Twin Engines", "VIP Transport", "Presidential Transport", "Executive Transport", "Utility", "Military"],
+{
+	"key": "AW-109 Power",
+	"altNames": [""], 
+	"tags": [],
 	"hltag": ["NCR"],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Sikorsky"
+              "key": "Manufacturer",
+              "value": "AgustaWestland"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "Italy"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "UH-60 Black Hawk, VH-3 Sea King, CH-53 Sea Stallion"
+              "key": "Similar Aircraft",
+              "value": "Bell 206, Bell 412"
               
           },
           {
-              "key": "Crew:",
+              "key": "Distinctive Features",
+              "value": "Lightweight, twin-engine utility helicopter with a sleek, modern fuselage and retractable landing gear."
+              
+          },
+
+          {
+              "key": "Crew",
               "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "VIP transport helicopter, primarily used for transporting the President of the United States (Marine One)"
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
           },
           {
-              "key": "Armament:",
-              "value": "Typically none in VIP configurations; equipped with defensive countermeasures for security"
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rockets, or anti-tank missiles"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 64 ft, 10 in (19.76 m), Rotor Diameter: 53 ft, 8 in (16.36 m)"
+              "key": "Dimensions",
+              "value": "Length: 13.05 meters (42 ft 10 in), Rotor Diameter: 11 meters (36 ft 1 in), Height: 3.5 meters (11 ft 6 in)"
           },            
           {
-              "key": "Names:",
-              "value": "VH-92 Patriot, VH-92, Patriot, Sikorsky"
+              "key": "Names",
+              "value": "AW-109 Power"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "No fixed wings; equipped with large sponsons on either side of the fuselage for housing landing gear and equipment."
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
           },
           {
-              "key": "Engine(s):",
-              "value": "Two turboshaft engines mounted above the fuselage with exhausts directed to the rear, positioned behind the rotor hub."
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted in the fuselage."
           },
           {
-              "key": "Fuselage:",
-              "value": "Large and robust fuselage with a sleek, angular design, featuring a pointed nose and expansive cabin space for VIP passengers. The helicopter has numerous windows for visibility and a side door for access."
+              "key": "Fuselage",
+              "value": "Sleek, streamlined fuselage with retractable landing gear for improved aerodynamics."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail boom with a large, horizontal stabilizer and a five-blade tail rotor mounted on the right side. The vertical stabilizer has a slightly angled design for improved aerodynamics."
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear of the fuselage."
           }          
       ]
-    },
-    {
-	"key": "E-3 Sentry",
-	"altNames": [""],
-	"tags": ["Plane", "Jet Plane", "Four Engines", "Jet", "Military", "Surveillance", "AWACS", "Airborne Early Warning", "Command and Control", "Radar"],
+	},
+{
+	"key": "Bell 206",
+	"altNames": [""], 
+	"tags": [],
 	"hltag": ["NCR"],
+	"accat":[""],
 	"generalData": [
           {
-              "key": "Manufacturer:",
-              "value": "Boeing"
+              "key": "Manufacturer",
+              "value": "Bell Helicopter"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Boeing 707, KC-135 Stratotanker"
+              "key": "Similar Aircraft",
+              "value": "AS-350 Squirrel, MD-500 Defender"
               
           },
           {
-              "key": "Crew:",
-              "value": "Three"
+              "key": "Distinctive Features",
+              "value": "Small, light utility helicopter with a distinctive bubble canopy and skids for landing."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
           },
           {
-              "key": "Role:",
-              "value": "Airborne Warning and Control System (AWACS), providing surveillance, command and control, and battle management"
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rockets, or anti-tank missiles"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 145 ft, 6 in (44.5 m), Span: 130 ft, 10 in (39.7 m) "
+              "key": "Dimensions",
+              "value": "Length: 12.03 meters (39 ft 6 in), Rotor Diameter: 10.16 meters (33 ft 4 in), Height: 2.98 meters (9 ft 9 in)"
           },            
           {
-              "key": "Names:",
+              "key": "Names",
+              "value": "Bell 206 "
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a two-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage with a bubble canopy and skids for landing."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "Bell 412",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bell Helicopter"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Bell 206, UH-1 Iroquois"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Medium utility helicopter with a four-blade main rotor and skids for landing."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns and rocket pods"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 17.10 meters (56 ft 1 in), Rotor Diameter: 14.02 meters (46 ft), Height: 4.57 meters (15 ft)"
+          },            
+          {
+              "key": "Names",
+              "value": "Bell 412"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted in the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Boxy fuselage with skids for landing, designed for utility and reconnaissance missions."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "EC-120",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Eurocopter"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "AS-350 Squirrel, Bell 206"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small, lightweight utility helicopter with a fenestron (enclosed) tail rotor."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 9.6 meters (31 ft 6 in), Rotor Diameter: 8.55 meters (28 ft 1 in), Height: 3.40 meters (11 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "EC-120"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a three-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "ingle turboshaft engine mounted inside the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage with a bubble canopy and a fenestron (enclosed) tail rotor for quieter operation."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a fenestron (enclosed) tail rotor."
+          }          
+      ]
+	},
+{
+	"key": "EC-135",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Eurocopter"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France / Germany"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "AS-350 Écureuil, EC-145"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small, lightweight utility helicopter with a fenestron tail rotor and sleek fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Medical Evacuation"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 10.2 meters (33 ft 6 in), Rotor Diameter: 10.2 meters (33 ft 6 in), Height: 3.5 meters (11 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "EC-135" 
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted inside the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Small, streamlined fuselage with a spacious cabin for passengers or medical equipment."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a fenestron tail rotor (enclosed within the tail structure)."
+          }          
+      ]
+	},
+{
+	"key": "HH-65 Dolphin",
+	"altNames": ["HH-65", "Dolphin"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Eurocopter"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "AS365 Dauphin, EC-135"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small utility helicopter with a fenestron tail rotor and sleek design."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Search and Rescue / Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11.5 meters (37 ft 9 in), Rotor Diameter: 11.9 meters (39 ft), Height: 3.51 meters (11 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "HH-65 Dolphin, HH-65, Dolphin"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboshaft engines mounted inside the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Small, streamlined fuselage with a spacious cabin for search and rescue operations."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a fenestron (enclosed) tail rotor mounted on the rear fuselage."
+          }          
+      ]
+	},
+{
+	"key": "Robinson R-44 Raven",
+	"altNames": ["Robinson R-44 Raven", "R-44" , "Raven", "Raven II"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Robinson Helicopter Company"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Bell 206"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small, lightweight utility helicopter with a two-blade main rotor and a compact fuselage."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Recon / Light Utility Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11.66 meters (38 ft 3 in), Rotor Diameter: 10.06 meters (33 ft), Height: 3.28 meters (10 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Robinson R-44 Raven, R-44, Raven"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a two-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single piston engine mounted inside the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Small, lightweight fuselage with a bubble canopy for high visibility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "AH-6 Little Bird",
+	"altNames": ["AH-6", "Little Bird"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Hughes Helicopters / Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MD-500 Defender, OH-58 Kiowa"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Compact, agile helicopter designed for special operations with a high maneuverability and dual rotor system."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Attack / Recon Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, rockets, and missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 9.07 meters (29 ft 9 in), Rotor Diameter: 8.00 meters (26 ft 3 in), Height: 2.50 meters (8 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "AH-6 Little Bird, AH-6, Little Bird"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a two-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact and lightweight fuselage designed for rapid maneuvering in tight spaces."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the right side of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "MI-2 Hoplite",
+	"altNames": ["MI-2", "Hoplite"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "PZL Świdnik"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Poland"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "BO-105, MD-500 Defender"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light utility helicopter with a two-blade main rotor and a compact design for versatility."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Recon Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns and light rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11.88 meters (39 ft 0 in), Rotor Diameter: 11.0 meters (36 ft 1 in), Height: 3.00 meters (9 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MI-2 Hoplite, MI-2, Hoplite"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a two-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage designed for light utility and reconnaissance missions."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "Gazelle",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Aérospatiale"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "BO-105, MD-500 Defender"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light utility helicopter with a distinctive slim fuselage and fenestron tail rotor."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Recon / Light Attack Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns, anti-tank missiles, and rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 13.50 meters (44 ft 3 in), Rotor Diameter: 10.80 meters (35 ft 5 in), Height: 3.23 meters (10 ft 7 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Gazelle"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slim fuselage designed for reconnaissance and light attack missions with a spacious cabin."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a fenestron (enclosed) tail rotor for reduced noise and increased safety."
+          }          
+      ]
+	},
+{
+	"key": "Bell 407",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bell Helicopter"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "AS350 Écureuil, Eurocopter EC135"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Four-blade main rotor, advanced avionics, and a spacious cabin designed for comfort and versatility."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Transport Helicopter"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with various armaments for law enforcement and utility missions"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11.63 meters (38 ft 2 in), Rotor Diameter: 10.67 meters (35 ft), Height: 3.51 meters (11 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Bell 407"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "No wings; features a four-blade main rotor for lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboshaft engine mounted in the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Spacious and modern fuselage designed for utility and passenger transport."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "MQ-1 Predator",
+	"altNames": ["MQ-1", "Predator"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "General Atomics"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MQ-9 Reaper"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Long, slender fuselage with a bulbous nose, and a V-tail configuration."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance / Strike"
+          },
+          {
+              "key": "Armament",
+              "value": "Two AGM-114 Hellfire missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 8.22 meters (27 ft), Wingspan: 14.84 meters (48 ft 8 in), Height: 2.10 meters (6 ft 11 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MQ-1 Predator, MQ-1, Predator"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Long, straight wings with external hardpoints for missiles."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single pusher-propeller engine mounted at the rear of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and slender fuselage with a bulbous nose housing sensors and communication equipment."
+          },     
+          {
+              "key": "Tail",
+              "value": "V-tail configuration mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "MQ-5B Hunter",
+	"altNames": ["MQ-5B", "Hunter"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Northrop Grumman"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "RQ-7 Shadow"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-boom design with a central fuselage pod and V-tail configuration."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance / Strike"
+          },
+          {
+              "key": "Armament",
+              "value": "Two GBU-44/B Viper Strike bombs"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 7.01 meters (23 ft), Wingspan: 10.49 meters (34 ft 5 in), Height: 2.08 meters (6 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MQ-5B Hunter, MQ-5B, Hunter"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Straight wings mounted on the central fuselage pod."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single pusher-propeller engine mounted at the rear of the fuselage pod."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Central fuselage pod with twin booms extending to the rear."
+          },     
+          {
+              "key": "Tail",
+              "value": "V-tail configuration mounted at the ends of the twin booms."
+          }          
+      ]
+	},
+{
+	"key": "MQ-9 Reaper",
+	"altNames": ["MQ-9", "Reaper"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "General Atomics"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MQ-1 Predator"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Long, slender fuselage, high-mounted wings, and a V-tail configuration."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance / Strike"
+          },
+          {
+              "key": "Armament",
+              "value": "Up to 1,700 kg of ordnance, including AGM-114 Hellfire missiles, GBU-12 Paveway II bombs, and GBU-38 JDAMs"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11 meters (36 ft), Wingspan: 20 meters (66 ft), Height: 3.81 meters (12 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MQ-9 Reaper, MQ-9, Reaper"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Long, straight wings with external hardpoints for carrying various ordnance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single pusher-propeller engine mounted at the rear of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and slender fuselage with a bulbous nose housing sensors and communication equipment."
+          },     
+          {
+              "key": "Tail",
+              "value": "V-tail configuration mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "MQ-8 Fire Scout",
+	"altNames": ["MQ-8", "Fire Scout"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Northrop Grumman"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Unmanned helicopter design with a traditional tail rotor and skids for landing."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance / Surveillance"
+          },
+          {
+              "key": "Armament",
+              "value": "Capable of carrying two Hellfire missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 9.44 meters (31 ft), Rotor Diameter: 8.38 meters (27 ft 6 in), Height: 2.95 meters (9 ft 8 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MQ-8 Fire Scout, MQ-8, Fire Scout"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Rotor blades mounted on top of the fuselage in a traditional helicopter configuration."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single engine mounted inside the fuselage with an exhaust at the rear."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined helicopter fuselage with sensors mounted on the nose."
+          },     
+          {
+              "key": "Tail",
+              "value": "Single vertical stabilizer with a tail rotor mounted on the rear."
+          }          
+      ]
+	},
+{
+	"key": "RQ-2 Pioneer",
+	"altNames": ["RQ-2", "Pioneer"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "AAI Corporation / Israel Aircraft Industries"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States / Israel"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-boom design with a high-mounted propeller engine and tailplane."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 4.27 meters (14 ft), Wingspan: 5.18 meters (17 ft), Height: 1.02 meters (3 ft 4 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "RQ-2 Pioneer, RQ-2, Pioneer"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Straight wings mounted high on the fuselage."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single pusher-propeller engine mounted high at the rear of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Twin-boom fuselage design with a central pod and long nose housing sensors."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin-boom tail with a horizontal stabilizer connecting the booms."
+          }          
+      ]
+	},
+{
+	"key": "RQ-4 Global Hawk",
+	"altNames": ["RQ-4", "Global Hawk"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Northrop Grumman"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "High-mounted wings, long fuselage with a bulbous nose, and V-tail configuration."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 14.50 meters (47 ft 7 in), Wingspan: 39.90 meters (130 ft 11 in), Height: 4.70 meters (15 ft 5 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "RQ-4 Global Hawk, RQ-4, Global Hawk"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted, straight wings with long wingspan for endurance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted at the rear of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and streamlined fuselage with a bulbous nose housing advanced sensor arrays."
+          },     
+          {
+              "key": "Tail",
+              "value": "V-tail configuration mounted at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "RQ-7 Shadow",
+	"altNames": ["RQ-7", "Shadow"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "AAI Corporation"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "MQ-5B Hunter"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-boom design with a central fuselage pod and inverted V-tail configuration."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 3.40 meters (11 ft 2 in), Wingspan: 4.27 meters (14 ft), Height: 0.91 meters (3 ft)"
+          },            
+          {
+              "key": "Names",
+              "value": "RQ-7 Shadow, RQ-7, Shadow"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Straight wings mounted on the central fuselage pod."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single pusher-propeller engine mounted at the rear of the fuselage pod."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Central fuselage pod with twin booms extending to the rear."
+          },     
+          {
+              "key": "Tail",
+              "value": "Inverted V-tail configuration mounted at the ends of the twin booms."
+          }          
+      ]
+	},
+{
+	"key": "RQ-170 Sentinel",
+	"altNames": ["RQ-170", "Sentinel"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Lockheed Martin"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Flying wing design with no tail, optimized for stealth."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: Classified, Wingspan: Estimated 20 meters (66 ft), Height: Classified"
+          },            
+          {
+              "key": "Names",
+              "value": "RQ-170 Sentinel, RQ-170, Sentinel"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Flying wing design with no distinct fuselage or tail."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single engine housed within the wing structure."
+          },
+          {
+              "key": "Fuselage",
+              "value": "No traditional fuselage; the aircraft is a flying wing optimized for stealth."
+          },     
+          {
+              "key": "Tail",
+              "value": "No tail due to the flying wing configuration."
+          }          
+      ]
+	},
+{
+	"key": "RQ-11B Raven",
+	"altNames": ["RQ-11B", "Raven"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "AeroVironment"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small hand-launched unmanned aircraft with a pusher-propeller and V-tail configuration."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 0.91 meters (3 ft), Wingspan: 1.37 meters (4 ft 6 in), Height: N/A"
+          },            
+          {
+              "key": "Names",
+              "value": "RQ-11B Raven, RQ-11B, Raven"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Straight wings mounted high on the fuselage."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single pusher-propeller engine mounted at the rear."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact and lightweight fuselage for hand launching."
+          },     
+          {
+              "key": "Tail",
+              "value": "V-tail configuration at the rear of the fuselage."
+          }          
+      ]
+	},
+{
+	"key": "ScanEagle",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Insitu / Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "RQ-11B Raven"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small, lightweight unmanned aircraft with a high-mounted pusher-propeller and long endurance capabilities."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 1.71 meters (5 ft 7 in), Wingspan: 3.11 meters (10 ft 2 in), Height: N/A"
+          },            
+          {
+              "key": "Names",
+              "value": "ScanEagle"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Straight wings mounted high on the fuselage."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single pusher-propeller engine mounted at the rear of the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slim fuselage designed for long endurance flights."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail with vertical and horizontal stabilizers."
+          }          
+      ]
+	},
+{
+	"key": "Shmel-1 Yak-061",
+	"altNames": ["Shmel-1", "Yak-061"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Yakovlev"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Russia"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small, unmanned aerial vehicle with a twin-boom design and pusher-propeller configuration."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Reconnaissance"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 2.7 meters (8 ft 10 in), Wingspan: 3.6 meters (11 ft 10 in), Height: N/A"
+          },            
+          {
+              "key": "Names",
+              "value": "Shmel-1 Yak-061, Shmel-1, Yak-061"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Straight wings mounted high on the fuselage."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single pusher-propeller engine mounted at the rear."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Small and compact twin-boom fuselage with a central pod for sensors."
+          },     
+          {
+              "key": "Tail",
+              "value": "Twin-boom tail configuration with a horizontal stabilizer connecting the booms."
+          }          
+      ]
+	},
+{
+	"key": "Mirach 100 Meteor",
+	"altNames": ["Mirach 100", "Meteor"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "SELEX Galileo"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Italy"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Small, unmanned aerial vehicle used primarily as a target drone."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Unmanned"
+          },
+          {
+              "key": "Role",
+              "value": "Unmanned Aircraft Platform / Target Drone"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 3.72 meters (12 ft 2 in), Wingspan: 2.43 meters (7 ft 11 in), Height: N/A"
+          },            
+          {
+              "key": "Names",
+              "value": "Mirach 100 Meteor, Mirach 100, Meteor"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted, straight wings designed for high-speed flight."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbojet engine mounted at the rear."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slim, cylindrical fuselage with a pointed nose."
+          },     
+          {
+              "key": "Tail",
+              "value": "V-tail configuration mounted at the rear."
+          }          
+      ]
+	},
+{
+	"key": "Airbus A300",
+	"altNames": ["A300"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Airbus"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Boeing 767, Airbus A320"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Wide-body twin-engine airliner with a distinctive wide fuselage and a two-deck layout."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Short to medium-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 54.40 meters (178 ft 1 in), Wingspan: 44.84 meters (147 ft 1 in), Height: 16.83 meters (55 ft 3 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Airbus A300, A300"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings with a significant wingspan for improved lift and fuel efficiency."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wide-body fuselage designed for passenger comfort and capacity, featuring a two-deck layout."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Airbus A320",
+	"altNames": ["A320"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Airbus"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Boeing 737, Airbus 300"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Narrow-body twin-engine airliner with a fly-by-wire control system and modern cockpit design."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Short to medium-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 37.57 meters (123 ft 3 in), Wingspan: 34.10 meters (111 ft 10 in), Height: 11.76 meters (38 ft 7 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Airbus 320, A320"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings with winglets for improved aerodynamics and fuel efficiency."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Narrow-body fuselage designed for efficient passenger transport with a modern layout."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Airbus A330",
+	"altNames": ["A330"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Airbus"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Boeing 767, Boeing 777"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Wide-body twin-engine airliner with a spacious cabin and long-range capabilities."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Long-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 63.68 meters (208 ft 10 in), Wingspan: 60.30 meters (197 ft 10 in), Height: 16.83 meters (55 ft 3 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Airbus A330, A330"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings with a large wingspan and winglets for aerodynamic efficiency."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wide-body fuselage designed for high passenger capacity and comfort."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Airbus A340",
+	"altNames": ["A340"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Airbus"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Boeing 747"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Four-engine wide-body airliner designed for long-haul flights with a high aspect ratio wing."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Long-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 75.36 meters (247 ft 0 in), Wingspan: 60.30 meters (197 ft 10 in), Height: 16.83 meters (55 ft 3 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Airbus A340, A340"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings with a significant wingspan and four engines for improved performance on long distances."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wide-body fuselage designed for comfort and passenger capacity over long distances."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Boeing 737",
+	"altNames": ["B737"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Airbus A320, McDonnell Douglas MD-80"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Narrow-body twin-engine airliner known for its reliability and extensive use in commercial aviation."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Short to medium-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 39.50 meters (129 ft 10 in), Wingspan: 35.79 meters (117 ft 5 in), Height: 12.50 meters (41 ft 0 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Boeing 737, B737"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings with a significant wingspan for efficient performance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Narrow-body fuselage designed for efficient passenger transport over short to medium distances."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Boeing 747",
+	"altNames": ["B747", "Airforce One"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Airbus A340"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Iconic humpbacked fuselage, large capacity, and four-engine design, known as the 'Jumbo Jet.'"
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Long-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 70.66 meters (231 ft 10 in), Wingspan: 68.4 meters (224 ft 7 in), Height: 19.41 meters (63 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Boeing 747, B747"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings with a wide wingspan designed for long-range flights."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wide-body fuselage designed for high passenger capacity and comfort on long journeys."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a large vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Boeing 757",
+	"altNames": ["B757"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Airbus A320, Boeing 767"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Narrow-body twin-engine airliner with a long fuselage and high aspect ratio wings."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Medium to long-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 38.05 meters (124 ft 10 in), Wingspan: 38.05 meters (124 ft 10 in), Height: 13.56 meters (44 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Boeing 757, B757"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings with winglets for improved fuel efficiency."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Narrow-body fuselage designed for efficient passenger transport over medium to long distances."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Boeing 767",
+	"altNames": ["B767"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Airbus A330, Boeing 757"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Wide-body twin-engine airliner designed for medium to long-haul flights, with a two-deck layout."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Medium to long-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 48.50 meters (159 ft 6 in), Wingspan: 47.57 meters (155 ft 0 in), Height: 15.85 meters (52 ft 0 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Boeing 767, B767"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for efficient performance during long-range flights."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wide-body fuselage designed for high passenger capacity and comfort on medium to long flights."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Boeing 777",
+	"altNames": ["B777"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Airbus A340, Boeing 787"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Wide-body twin-engine airliner with a large diameter fuselage and advanced technology systems."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Long-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 63.70 meters (208 ft 10 in), Wingspan: 60.93 meters (199 ft 11 in), Height: 18.50 meters (60 ft 8 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Boeing 777, B777"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings with a significant wingspan and raked wingtips for aerodynamic efficiency."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two high-thrust turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wide-body fuselage designed for maximum passenger comfort and capacity on long flights."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a large vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Boeing 787",
+	"altNames": ["B787"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Airbus A330, Boeing 777"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Wide-body twin-engine airliner known for its lightweight composite structure and fuel efficiency."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Long-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 62.80 meters (206 ft 0 in), Wingspan: 60.10 meters (197 ft 4 in), Height: 16.83 meters (55 ft 3 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Boeing 787, B787"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings with a large wingspan and advanced wing design for improved aerodynamics."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two high-bypass turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Composite fuselage designed for lightweight and fuel efficiency, allowing for larger windows and improved passenger comfort."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Cessna 500 Citation",
+	"altNames": ["Cessna 500", "Citation"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Cessna Aircraft Company"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Hawker 800, Learjet 45"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light jet with a low-wing design and T-tail, known for its spacious cabin and reliability."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Business Jet"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 15.85 meters (52 ft 0 in), Wingspan: 15.76 meters (51 ft 8 in), Height: 4.57 meters (15 ft 0 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Cessna 500 Citation, Cessna 500, Citation"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for aerodynamics and efficiency."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Sleek fuselage designed for business travel, featuring a spacious cabin with ample headroom."
+          },     
+          {
+              "key": "Tail",
+              "value": "T-tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Dassault Falcon 50",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Dassault Aviation"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Bombardier Challenger, Gulfstream"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Tri-jet configuration with two engines mounted on the wings and one on the rear fuselage, offering high speed and efficiency."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Business Jet"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 19.70 meters (64 ft 7 in), Wingspan: 20.30 meters (66 ft 7 in), Height: 6.10 meters (20 ft 0 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Dassault Falcon 50"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Mid-mounted wings with a significant wingspan designed for aerodynamics and stability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Three turbofan engines; two mounted on the wings and one on the fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a spacious and luxurious cabin for business travel."
+          },     
+          {
+              "key": "Tail",
+              "value": "T-tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Gulf Stream",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Gulfstream Aerospace"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Bombardier Challenger, Cessna 500 Citation "
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Long-range business jet with a sleek design, high cruising speed, and spacious cabin for maximum comfort."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Business Jet"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 29.39 meters (96 ft 5 in), Wingspan: 28.65 meters (94 ft 0 in), Height: 7.43 meters (24 ft 5 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Gulf Stream"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for aerodynamic efficiency and performance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long and streamlined fuselage designed for luxury and comfort on long flights."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Hawker 800",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Hawker Beechcraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Cessna 500 Citation, Bombardier Learjet "
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Mid-sized business jet with a spacious cabin and two-engine configuration, designed for comfort and efficiency."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Business Jet"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 15.85 meters (52 ft 0 in), Wingspan: 15.16 meters (49 ft 9 in), Height: 4.88 meters (16 ft 0 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Hawker 800"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings with winglets for improved fuel efficiency and stability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage with a comfortable cabin designed for business travel."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Lear Jet",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bombardier Aerospace"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Canada"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Cessna 500 Citation, Gulfstream "
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Lightweight business jet known for its speed and range, featuring a low-wing design and twin-engine configuration."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Business Jet"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 14.83 meters (48 ft 8 in), Wingspan: 13.18 meters (43 ft 3 in), Height: 4.27 meters (14 ft 0 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Lear Jet"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for aerodynamic efficiency and high-speed performance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Sleek, compact fuselage optimized for passenger comfort during business travel."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Challenger",
+	"altNames": ["Bombardier Aerospace"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bombardier Aerospace"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Canada"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Cessna Citation "
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Mid-sized business jet with a spacious cabin and a distinctive wide fuselage designed for comfort and performance."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Regional Jet / Business Jet"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 20.24 meters (66 ft 5 in), Wingspan: 20.29 meters (66 ft 7 in), Height: 6.10 meters (20 ft 0 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Challenger"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": " Low-mounted wings with winglets for improved aerodynamic performance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wide-body fuselage designed for comfort and passenger capacity."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "CRJ-100",
+	"altNames": ["CRJ"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bombardier Aerospace"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Canada"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Embraer ERJ-145, Dash 8"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Regional jet with a slender fuselage and T-tail design, optimized for short to medium-haul routes."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Regional Jet"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 26.77 meters (87 ft 10 in), Wingspan: 23.1 meters (75 ft 9 in), Height: 6.00 meters (19 ft 8 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "CRJ, CRJ-100"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for efficient lift on regional flights."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slender fuselage designed for regional passenger transport, offering a comfortable cabin layout."
+          },     
+          {
+              "key": "Tail",
+              "value": "T-tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "MD-80",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "McDonnell Douglas"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Boeing 737, Airbus A320"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Narrow-body twin-engine airliner known for its T-tail configuration and spacious cabin."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Medium-haul airliner"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 33.3 meters (109 ft 11 in), Wingspan: 32.3 meters (106 ft 0 in), Height: 8.76 meters (28 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MD-80"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings with a significant wingspan for medium-haul efficiency."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Narrow-body fuselage designed for comfortable passenger travel with ample headroom."
+          },     
+          {
+              "key": "Tail",
+              "value": "T-tail configuration with a large vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "ERJ-145",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Embraer"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Brazil"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Bombardier CRJ-100, Bombardier Dash 8"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Regional jet with a slender fuselage and T-tail, designed for regional travel with a comfortable passenger layout."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Regional Jet"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 29.87 meters (98 ft 0 in), Wingspan: 20.80 meters (68 ft 3 in), Height: 6.0 meters (19 ft 8 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "ERJ-145"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for efficient lift on regional flights."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slender fuselage designed for regional passenger transport, providing a comfortable cabin layout."
+          },     
+          {
+              "key": "Tail",
+              "value": "T-tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "ERJ-170",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Embraer"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Brazil"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Bombardier CRJ-900, Airbus A220"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Larger regional jet with a spacious cabin and modern avionics, known for its fuel efficiency."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Regional Jet"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 29.90 meters (98 ft 1 in), Wingspan: 26.00 meters (85 ft 4 in), Height: 7.34 meters (24 ft 1 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "ERJ-170"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings with winglets for improved aerodynamic performance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted under the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wider fuselage designed for increased passenger comfort and capacity on regional routes."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "E-3 Sentry",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Wide-body aircraft equipped with a rotating radar dome on top for airborne early warning and control."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two pilots, with up to 15 mission specialists"
+          },
+          {
+              "key": "Role",
+              "value": "Airborne Warning and Control System (AWACS)"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 46.80 meters (153 ft 10 in), Wingspan: 44.42 meters (145 ft 0 in), Height: 12.5 meters (41 ft 0 in)"
+          },            
+          {
+              "key": "Names",
               "value": "E-3 Sentry"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with wide chord and integrated fuel tanks."
+              "key": "Wings",
+              "value": "High-mounted wings designed for stability and lift, accommodating the large radar dome."
           },
           {
-              "key": "Engine(s):",
-              "value": "Four turbofan engines mounted under the wings, evenly spaced along the leading edges."
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted under the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Long and cylindrical fuselage with a distinctive large, circular radar mounted on top, providing 360-degree radar coverage. The nose is slightly pointed, and the fuselage is derived from the Boeing 707 airframe, featuring numerous antennae and mission-related equipment on the surface."
+              "key": "Fuselage",
+              "value": "Wide-body fuselage designed for extensive crew and equipment capacity, optimized for surveillance operations."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail with a single vertical stabilizer and horizontal stabilizers mounted low on the fuselage. The vertical stabilizer is typical of the Boeing 707 design, but the E-3's large radome gives the aircraft a unique silhouette."
-          }         
+              "key": "Tail",
+              "value": "Conventional tail configuration with a large vertical stabilizer."
+          }          
       ]
-    },
-    {    
-  	"key": "KC-135 Stratotanker",
-   	"altNames": ["KC-135", "Stratotanker"],
-	"tags": ["Plane", "Jet Plane", "Four Engines", "Jet", "Military", "Tanker", "Aerial Refueling", "Transport"],
-	"hltag": ["NCR"], 
-   	"generalData": [
+	},
+{
+	"key": "KC-135 Stratotanker",
+	"altNames": ["KC-135", "Stratotanker"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
           {
-              "key": "Manufacturer:",
+              "key": "Manufacturer",
               "value": "Boeing"
           },  
           {
-              "key": "Country of Origin:",
-              "value": "US"
+              "key": "Country of Origin",
+              "value": "United States"
           },
           {
-              "key": "Similar Aircraft:",
-              "value": "Boeing 707, E-3 Sentry"
+              "key": "Similar Aircraft",
+              "value": "Airbus A330 MRTT, Il-78"
               
           },
           {
-              "key": "Crew:",
-              "value": "Three"
+              "key": "Distinctive Features",
+              "value": "Military aerial refueling aircraft based on the Boeing 707 design, with a fuselage-mounted boom for fuel transfer."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Three (pilot, co-pilot, boom operator)"
           },
           {
-              "key": "Role:",
-              "value": "Aerial refueling"
+              "key": "Role",
+              "value": "Aerial Refueling"
           },
           {
-              "key": "Armament:",
-              "value": "NONE"
+              "key": "Armament",
+              "value": "Unarmed"
           }, 
           {
-              "key": "Dimensions:",
-              "value": "Length: 136 ft, 3 in (41.5 m), Span: 130 ft, 10 in (39.9 m)"
+              "key": "Dimensions",
+              "value": "Length: 46.61 meters (153 ft 0 in), Wingspan: 39.88 meters (130 ft 1 in), Height: 13.25 meters (43 ft 6 in)"
           },            
           {
-              "key": "Names:",
+              "key": "Names",
               "value": "KC-135 Stratotanker, KC-135, Stratotanker"
           }                      
       ],
       "weftDescription": [
           {
-              "key": "Wings:",
-              "value": "Low-mounted, swept-back wings with slight taper and integrated fuel tanks near the wingtips."
+              "key": "Wings",
+              "value": "High-mounted wings designed for stability and fuel capacity."
           },
           {
-              "key": "Engine(s):",
-              "value": "Four turbofan engines mounted under the wings, evenly spaced along the leading edges."
+              "key": "Engine(s)",
+              "value": "Four turbofan engines mounted under the wings."
           },
           {
-              "key": "Fuselage:",
-              "value": "Cylindrical fuselage with a pointed nose and slightly bulging midsection. The KC-135’s fuselage is adapted for refueling, with a boom extending from the rear underside for air-to-air refueling operations."
+              "key": "Fuselage",
+              "value": "Wide-body fuselage designed to accommodate fuel tanks and crew for aerial refueling operations."
           },     
           {
-              "key": "Tail:",
-              "value": "Conventional tail design with a single vertical stabilizer and low-mounted horizontal stabilizers. The tail boom extends from the lower rear of the fuselage for refueling other aircraft in flight."
+              "key": "Tail",
+              "value": "Conventional tail configuration with a large vertical stabilizer."
           }          
       ]
-    }
+	},
+{
+	"key": "T-38 Talon",
+	"altNames": ["T-38", "Talon"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Northrop"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Aermacchi MB-339, BAE Systems Hawk"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine jet trainer with a tandem seating arrangement, designed for advanced flight training."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Advanced Jet Trainer"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 12.74 meters (41 ft 10 in), Wingspan: 9.08 meters (29 ft 10 in), Height: 3.18 meters (10 ft 5 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "T-38 Talon, T-38, Talon"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings with a slight sweep for improved performance at high speeds."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbofan engines mounted on the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slender fuselage designed for high-speed training with a tandem cockpit for instructor and student."
+          },     
+          {
+              "key": "Tail",
+              "value": "T-tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "L-39 Albatross",
+	"altNames": ["L-39", "Albatross"], 
+	"tags": [],
+	"hltag": ["devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Aero Vodochody"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Czech Republic"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Aero L-59 Super Albatross, Cessna A-37 Dragon Fly"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Jet trainer with a low-wing design and tandem seating, widely used for pilot training."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Jet Trainer / Light Attack"
+          },
+          {
+              "key": "Armament",
+              "value": " Can be fitted with bombs, rockets, and machine guns"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 12.67 meters (41 ft 7 in), Wingspan: 9.40 meters (30 ft 10 in), Height: 4.14 meters (13 ft 7 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "L-39 Albatross, L-39, Albatross"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for stability and performance during training."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage designed for training and light attack missions."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "CM-170 Magister",
+	"altNames": ["CM-170", "Magister"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Fouga"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "L-39 Albatross, MBB Bo 105"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine jet trainer with a unique canard configuration, designed for advanced flight training."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Advanced Jet Trainer"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with light bombs or rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 10.40 meters (34 ft 1 in), Wingspan: 10.40 meters (34 ft 1 in), Height: 2.96 meters (9 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "CM-170 Magister"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Mid-mounted wings with a canard configuration for enhanced maneuverability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turbojet engines mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slim fuselage designed for agility and training effectiveness."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "MB-339AN",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Alenia Aermacchi"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Italy"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "L-39 Albatross, T-6 Texan II"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Advanced jet trainer featuring a low-wing design and a tandem seating arrangement."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Advanced Jet Trainer"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with light bombs and rockets"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 12.50 meters (41 ft), Wingspan: 9.30 meters (30 ft 6 in), Height: 3.40 meters (11 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MB-339AN"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": " Low-mounted wings designed for optimal lift and maneuverability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turbofan engine mounted in the rear fuselage."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage designed for efficient training operations."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "PC-7",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Pilatus Aircraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Switzerland"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "T-6 Texan II, Beechcraft T-34 Mentor"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Single-engine turboprop trainer known for its agility and low operational costs."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Trainer / Light Attack"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns and light bombs"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 12.56 meters (41 ft 2 in), Wingspan: 11.02 meters (36 ft 2 in), Height: 3.41 meters (11 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "PC-7"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for optimal performance in training missions."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single turboprop engine mounted in the front."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slim fuselage designed for efficient training operations."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Beechcraft Baron",
+	"altNames": ["Beech Baron"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Beechcraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Piper Navajo, Cessna 310"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine light aircraft known for its spacious cabin and versatility for both private and business use."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Light Transport / Utility"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 8.63 meters (28 ft 4 in), Wingspan: 11.80 meters (38 ft 9 in), Height: 2.90 meters (9 ft 6 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Beechcraft Baron, Beech Baron"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "-mounted wings with a slight dihedral for stability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two piston engines mounted on the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Spacious fuselage designed for comfort and utility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Spacious fuselage designed for comfort and utility."
+          }          
+      ]
+	},
+{
+	"key": "Beechcraft Bonanza",
+	"altNames": ["Beech Bonanza"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Beechcraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Cessna 182, Mooney M20"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Single-engine aircraft known for its distinctive V-tail (in some models) and performance in both personal and business travel."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Light Transport / Utility"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 7.34 meters (24 ft 1 in), Wingspan: 10.6 meters (34 ft 9 in), Height: 2.54 meters (8 ft 4 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Beechcraft Bonanza, Beech Bonanza"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings with a sleek design for improved aerodynamics."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single piston engine mounted in the front."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage designed for comfort and passenger space."
+          },     
+          {
+              "key": "Tail",
+              "value": "V-tail configuration (on some models) or conventional tail with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Cessna 172 Skyhawk",
+	"altNames": ["Cessna 172", "Skyhawk"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Cessna"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Piper PA-28 Cherokee, Grumman American AA-5"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "High-wing, single-engine aircraft widely used for flight training and personal use, known for its stability and ease of handling."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Light Utility / Trainer"
+          },
+          {
+              "key": "Armament",
+              "value": "Typically Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 8.28 meters (27 ft 1 in), Wingspan: 10.92 meters (35 ft 10 in), Height: 2.74 meters (9 ft 0 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Cessna 172 Skyhawk, Cessna 172, Skyhawk"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for stability and visibility."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single piston engine mounted in the front."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Small but spacious fuselage designed for comfort and utility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Cessna 310",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Cessna"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Beechcraft Baron, Piper Navajo"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine aircraft known for its performance, comfort, and capability for both personal and business travel."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Light Transport / Utility"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 8.15 meters (26 ft 9 in), Wingspan: 11.84 meters (38 ft 10 in), Height: 2.67 meters (8 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Cessna 310"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings with a slight dihedral for stability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two piston engines mounted on the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Streamlined fuselage designed for passenger comfort and utility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Cessna 421 Golden Eagle",
+	"altNames": ["Cessna 421", "Golden Eagle"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Cessna"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Beechcraft Baron, Piper Navajo"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine aircraft with a high-wing design, known for its spacious cabin and performance."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Light Transport / Utility"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 11.80 meters (38 ft 9 in), Wingspan: 12.60 meters (41 ft 4 in), Height: 3.60 meters (11 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Cessna 421 Golden Eagle, Cessna 421, Golden Eagle"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings with a significant wingspan for stability and lift."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two piston engines mounted on the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Spacious fuselage designed for passenger comfort and utility."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Beechcraft King Air",
+	"altNames": ["Beech King Air"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Beechcraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Piper Navajo, Cessna 421 Golden Eagle"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine turboprop utility aircraft known for its versatility and reliability in both civilian and military applications."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Transport / Special Mission"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed (in civilian configuration); can be equipped for special mission roles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 13.36 meters (43 ft 10 in), Wingspan: 16.61 meters (54 ft 6 in), Height: 4.52 meters (14 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Beechcraft King Air, Beech King Air"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted, straight wings with large winglets for improved performance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted on the wings, each with four-bladed propellers."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slim, cylindrical fuselage designed for utility and transport, accommodating both passengers and cargo."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer and horizontal stabilizers mounted low."
+          }          
+      ]
+	},
+{
+	"key": "Dash 8",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bombardier Aerospace"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Canada"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "ATR 72, Embraer EMB 120 Brasilia"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine turboprop regional airliner known for its high-wing design and short takeoff and landing capabilities."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Regional Transport"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 19.69 meters (64 ft 7 in), Wingspan: 24.57 meters (80 ft 3 in), Height: 7.85 meters (25 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Dash 8"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for optimal lift and fuel efficiency."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted on the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wide fuselage designed for regional passenger transport with a comfortable cabin layout."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Mooney M-22 Mustang",
+	"altNames": ["Mooney Mustang", "M-22"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Mooney International Corporation"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Cessna 172, Piper PA-28"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light aircraft with a low-wing configuration and distinctive T-tail design, known for its speed and efficiency."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Light Utility"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 7.64 meters (25 ft 1 in), Wingspan: 9.68 meters (31 ft 9 in), Height: 2.82 meters (9 ft 3 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Mooney M-22 Mustang, Mooney Mustang, M-22"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for speed and stability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single piston engine mounted in the nose."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage designed for efficient travel and handling."
+          },     
+          {
+              "key": "Tail",
+              "value": "T-tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Piper PA-18 Cub",
+	"altNames": ["Piper Cub", "PA-18"], 
+	"tags": [],
+	"hltag": ["NCR","devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Piper Aircraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Aeronca Champ, Taylorcraft BC-12"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Light aircraft with a high-wing design, known for its excellent short takeoff and landing (STOL) capabilities."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Light Utility / Trainer"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 6.89 meters (22 ft 7 in), Wingspan: 10.67 meters (35 ft 0 in), Height: 2.26 meters (7 ft 5 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Piper PA-18 Cub, Piper Cub, PA-18"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for STOL performance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single piston engine mounted in the front"
+          },
+          {
+              "key": "Fuselage",
+              "value": "Simple and lightweight fuselage optimized for utility and ease of handling."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Piper PA-28 Cherokee",
+	"altNames": ["Piper Cherokee", "PA-28"], 
+	"tags": [],
+	"hltag": ["NCR", "devtest"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Piper Aircraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Cessna 172, Beechcraft Musketeer"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Low-wing, single-engine aircraft designed for flight training and personal use, known for its stability and reliability."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Trainer / Light Utility"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 7.34 meters (24 ft 1 in), Wingspan: 10.92 meters (35 ft 10 in), Height: 2.69 meters (8 ft 10 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Piper PA-28 Cherokee, Piper Cherokee, PA-28"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for stability and visibility."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single piston engine mounted in the front."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Compact fuselage designed for comfortable passenger transport and training."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "SR-22",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Cirrus Aircraft"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Mooney M20, Cessna 182"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Single-engine light aircraft with a sleek design and advanced avionics, known for its safety features."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Light Utility / Personal"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 7.92 meters (26 ft 0 in), Wingspan: 11.68 meters (38 ft 4 in), Height: 2.79 meters (9 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "SR-22"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for performance and efficiency."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single piston engine mounted in the front."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Modern fuselage designed for comfort and advanced technology integration."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "Saab 340",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Saab"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Sweden"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Dash 8, ATR 42"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine turboprop airliner designed for regional transport with a spacious cabin."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Regional Transport / Utility"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 22.93 meters (75 ft 3 in), Wingspan: 21.29 meters (69 ft 10 in), Height: 7.55 meters (24 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "Saab 340" 
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Low-mounted wings designed for efficiency and stability during flight."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted on the wings."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Wide fuselage designed for passenger comfort and capacity."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "ATR-72",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "ATR (Aerei da Trasporto Regionale)"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "France / Italy"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Dash 8, Saab 340"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine turboprop regional airliner with a high-wing design, known for its short takeoff and landing capabilities and efficient fuel consumption."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Regional Transport / Utility"
+          },
+          {
+              "key": "Armament",
+              "value": "Unarmed"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 27.17 meters (89 ft 2 in), Wingspan: 27.05 meters (88 ft 9 in), Height: 7.65 meters (25 ft 1 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "ATR-72"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for excellent lift and fuel efficiency, equipped with winglets."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted on the wings, each with six-bladed propellers."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Long, cylindrical fuselage designed for passenger and cargo transport, with a spacious cabin and rear loading capabilities."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer and horizontal stabilizers mounted at mid-level."
+          }          
+      ]
+	},
+{
+	"key": "An-2 Colt",
+	"altNames": ["An-2", "Colt"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Antonov"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "Soviet Union"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "De Havilland DHC-3 Otter, Pilatus PC-6"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Biplane with a high-wing design, known for its STOL capabilities and versatility in utility roles."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "One"
+          },
+          {
+              "key": "Role",
+              "value": "Utility / Crop Duster"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with machine guns or other light weapons"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 12.3 meters (40 ft 4 in), Wingspan: 18.0 meters (59 ft 1 in), Height: 4.2 meters (13 ft 9 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "An-2 Colt, An-2, Colt"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted biplane wings designed for excellent lift and STOL performance."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Single piston engine mounted in the front."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Robust fuselage designed for cargo and passenger transport."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "O-2 Skymaster",
+	"altNames": ["O-2", "Skymaster"], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Cessna"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "Piper PA-25 Pawnee, Beechcraft Baron"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Twin-engine observation and light attack aircraft with a unique push-pull configuration."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Two"
+          },
+          {
+              "key": "Role",
+              "value": "Forward Air Control / Light Attack"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be fitted with rockets, bombs, and machine guns"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "CLength: 8.10 meters (26 ft 6 in), Wingspan: 12.60 meters (41 ft 4 in), Height: 2.80 meters (9 ft 2 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "O-2 Skymaster, O-2, Skymaster"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "High-mounted wings designed for excellent visibility and stability."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two piston engines; one in the front and one in the rear."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Slim fuselage designed for observation and light attack missions."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a single vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "MV-22 Osprey",
+	"altNames": ["MV-22", "Osprey"], 
+	"tags": [],
+	"hltag": ["NCR"],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": "Bell Boeing"
+          },  
+          {
+              "key": "Country of Origin",
+              "value": "United States"
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": "None"
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": "Tiltrotor aircraft capable of vertical takeoff and landing, combining the speed of a fixed-wing aircraft with the versatility of a helicopter."
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": "Four"
+          },
+          {
+              "key": "Role",
+              "value": "Multirole Transport / Assault"
+          },
+          {
+              "key": "Armament",
+              "value": "Can be equipped with machine guns and missiles"
+          }, 
+          {
+              "key": "Dimensions",
+              "value": "Length: 17.57 meters (57 ft 8 in), Rotor Diameter: 11.6 meters (38 ft 1 in), Height: 4.57 meters (15 ft 0 in)"
+          },            
+          {
+              "key": "Names",
+              "value": "MV-22 Osprey, MV-22, Osprey"
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": "Tiltrotor design with rotors that can pivot for vertical takeoff and forward flight."
+          },
+          {
+              "key": "Engine(s)",
+              "value": "Two turboprop engines mounted on the nacelles."
+          },
+          {
+              "key": "Fuselage",
+              "value": "Sleek fuselage designed for speed and agility, with a large cabin for cargo or personnel."
+          },     
+          {
+              "key": "Tail",
+              "value": "Conventional tail configuration with a vertical stabilizer."
+          }          
+      ]
+	},
+{
+	"key": "",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": ""
+          },  
+          {
+              "key": "Country of Origin",
+              "value": ""
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": ""
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": ""
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": ""
+          },
+          {
+              "key": "Role",
+              "value": ""
+          },
+          {
+              "key": "Armament",
+              "value": ""
+          }, 
+          {
+              "key": "Dimensions",
+              "value": ""
+          },            
+          {
+              "key": "Names",
+              "value": ""
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": ""
+          },
+          {
+              "key": "Engine(s)",
+              "value": ""
+          },
+          {
+              "key": "Fuselage",
+              "value": ""
+          },     
+          {
+              "key": "Tail",
+              "value": ""
+          }          
+      ]
+	},
+{
+	"key": "",
+	"altNames": [""], 
+	"tags": [],
+	"hltag": [""],
+	"accat":[""],
+	"generalData": [
+          {
+              "key": "Manufacturer",
+              "value": ""
+          },  
+          {
+              "key": "Country of Origin",
+              "value": ""
+          },
+          {
+              "key": "Similar Aircraft",
+              "value": ""
+              
+          },
+          {
+              "key": "Distinctive Features",
+              "value": ""
+              
+          },
+
+          {
+              "key": "Crew",
+              "value": ""
+          },
+          {
+              "key": "Role",
+              "value": ""
+          },
+          {
+              "key": "Armament",
+              "value": ""
+          }, 
+          {
+              "key": "Dimensions",
+              "value": ""
+          },            
+          {
+              "key": "Names",
+              "value": ""
+          }                      
+      ],
+      "weftDescription": [
+          {
+              "key": "Wings",
+              "value": ""
+          },
+          {
+              "key": "Engine(s)",
+              "value": ""
+          },
+          {
+              "key": "Fuselage",
+              "value": ""
+          },     
+          {
+              "key": "Tail",
+              "value": ""
+          }          
+      ]
+	}
 ]


### PR DESCRIPTION
>Update Notes:
  >Overhauled list
    >Added 92 new unique aircraft to bring the total count to 152.
    >Organize aircraft into the following groups
      >Fighter Jets
      >Bombers
      >Transport & Cargo
      >Helicopters
      >UAS
      >Airliners
      >Business & Regional Jets
      >Military Special Mission Aircraft
      >Trainers
      >Civilian Propeller
      >Tiltrotor 
    >Updated Verbiage to original 60 aircraft to be more consistent with new addition.
    >Added "accat" (AirCraft CATegory) to all aircraft. 
      >This is meant to notate which category the aircraft belongs to help filter aircraft in the future 
      > filled in accat in a hand full of aircraft to get rough idea of what I want. 
      > Will finish adding accat to all aircraft in a later update.
    >Added new section in "generalData" called "Distinctive Features"
      >"Distinctive Features" is to describe distinctive features on aircraft. 
      > This is import for the Aircraft Similarity Scoring program to run. (Still workshopping a name, will be called something different in the future)
  >Add New hltags
    >NCR(OG 60 aircraft)
    >devtest(randomly selected aircraft to have a smaller list to filter into for features testing. Will delete later)