### PR TITLE
Update aircraft-meta.json

### DIFF
--- a/public/aircraft-meta.json
+++ b/public/aircraft-meta.json
@@ -1,10 +1,35 @@
 [
   {
     "key": "A-10 Thunderbolt II",
-    "altNames": ["A-10", "Thunderbolt II", "Thunderbolt"],
-    "tags": ["Ground Attack", "CAS", "USA", "Cold War"],
-    "hltag": ["devtest", "Fixed-Wing", "Attack"],
-    "accat": ["Ground Attack", "Close Air Support", "Fighter Bomber"],
+    "altNames": [
+      "A-10 Thunderbolt II",
+      "A-10",
+      "Thunderbolt II",
+      "Thunderbolt"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "tags": [
+      "Ground Attack",
+      "CAS",
+      "USA",
+      "Cold War"
+    ],
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -76,7 +101,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin engines on rear fuselage", "GAU-8/A Avenger cannon"]
+        "distinctiveFeatures": [
+          "twin engines on rear fuselage",
+          "GAU-8/A Avenger cannon"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -95,10 +123,34 @@
   },
   {
     "key": "SU-25 Frogfoot",
-    "altNames": ["SU-25", "Frogfoot"],
-    "tags": ["Ground Attack", "CAS", "Russia/USSR", "Cold War"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Attack"],
+    "altNames": [
+      "SU-25 Frogfoot",
+      "SU-25",
+      "Frogfoot"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "tags": [
+      "Ground Attack",
+      "CAS",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -170,7 +222,10 @@
       },
       "fuselage": {
         "shape": "armored",
-        "distinctiveFeatures": ["large cockpit canopy", "heavily armored"]
+        "distinctiveFeatures": [
+          "large cockpit canopy",
+          "heavily armored"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -189,10 +244,36 @@
   },
   {
     "key": "Su-17/20/22 Fitter",
-    "altNames": ["Su-17", "Su-20", "Su-22", "Fitter"],
-    "tags": ["Ground Attack", "Fighter Bomber", "Russia/USSR", "Cold War"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Attack"],
+    "altNames": [
+      "SU-25 Frogfoot",
+      "Su-17",
+      "Su-20",
+      "Su-22",
+      "Fitter"
+    ],
+    "tags": [
+      "Ground Attack",
+      "Fighter Bomber",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -264,7 +345,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["variable-sweep wings", "rugged airframe"]
+        "distinctiveFeatures": [
+          "variable-sweep wings",
+          "rugged airframe"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -282,10 +366,33 @@
   },
   {
     "key": "AMX",
-    "altNames": ["AMX International", "International"],
-    "tags": ["Ground Attack", "CAS", "Italy", "Brazil"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Attack"],
+    "altNames": [
+      "AMX",
+      "AMX International",
+      "International"
+    ],
+    "tags": [
+      "Ground Attack",
+      "CAS",
+      "Italy",
+      "Brazil"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -357,7 +464,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["high-mounted tail", "single-engine"]
+        "distinctiveFeatures": [
+          "high-mounted tail",
+          "single-engine"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -376,10 +486,36 @@
   },
   {
     "key": "AV-8 Harrier II",
-    "altNames": ["AV-8", "Harrier II", "Harrier"],
-    "tags": ["Ground Attack", "VTOL/STOL", "CAS", "USA", "UK"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Attack", "VTOL/STOL"],
+    "altNames": [
+      "AV-8 Harrier II",
+      "AV-8",
+      "Harrier II",
+      "Harrier"
+    ],
+    "tags": [
+      "Ground Attack",
+      "VTOL/STOL",
+      "CAS",
+      "USA",
+      "UK"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack",
+      "VTOL/STOL"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -451,7 +587,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["VTOL capability", "vectoring nozzles"]
+        "distinctiveFeatures": [
+          "VTOL capability",
+          "vectoring nozzles"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -470,10 +609,32 @@
   },
   {
     "key": "Sepecat Jaguar",
-    "altNames": ["Jaguar"],
-    "tags": ["Ground Attack", "CAS", "UK", "France"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Attack"],
+    "altNames": [
+      "Sepecat Jaguar",
+      "Jaguar"
+    ],
+    "tags": [
+      "Ground Attack",
+      "CAS",
+      "UK",
+      "France"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -545,7 +706,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["high-mounted tail", "twin engines"]
+        "distinctiveFeatures": [
+          "high-mounted tail",
+          "twin engines"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -564,10 +728,32 @@
   },
   {
     "key": "Q-5 Fantan ",
-    "altNames": ["Q-5", "Fantan "],
-    "tags": ["Ground Attack", "CAS", "China"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Attack"],
+    "altNames": [
+      "Q-5 Fantan ",
+      "Q-5",
+      "Fantan "
+    ],
+    "tags": [
+      "Ground Attack",
+      "CAS",
+      "China"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -639,7 +825,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["nose-mounted intake", "delta wing"]
+        "distinctiveFeatures": [
+          "nose-mounted intake",
+          "delta wing"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -658,10 +847,33 @@
   },
   {
     "key": "Su-24 Fencer",
-    "altNames": ["Su-24", "Fencer"],
-    "tags": ["Ground Attack", "Fighter Bomber", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Attack", "Bomber"],
+    "altNames": [
+      "Su-24 Fencer",
+      "Su-24",
+      "Fencer"
+    ],
+    "tags": [
+      "Ground Attack",
+      "Fighter Bomber",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack",
+      "Bomber"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -733,7 +945,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["side-by-side seating", "variable-sweep wings"]
+        "distinctiveFeatures": [
+          "side-by-side seating",
+          "variable-sweep wings"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -751,10 +966,34 @@
   },
   {
     "key": "Tornado IDS",
-    "altNames": ["Tornado"],
-    "tags": ["Ground Attack", "Fighter Bomber", "UK", "Germany", "Italy"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Attack", "Bomber"],
+    "altNames": [
+      "Tornado IDS",
+      "Tornado"
+    ],
+    "tags": [
+      "Ground Attack",
+      "Fighter Bomber",
+      "UK",
+      "Germany",
+      "Italy"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack",
+      "Bomber"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -826,7 +1065,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["variable-sweep wings", "twin engines"]
+        "distinctiveFeatures": [
+          "variable-sweep wings",
+          "twin engines"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -845,10 +1087,32 @@
   },
   {
     "key": "A-37 Dragon Fly",
-    "altNames": ["A-37", "Dragon Fly"],
-    "tags": ["Light Attack", "CAS", "USA"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Light Attack"],
+    "altNames": [
+      "A-37 Dragon Fly",
+      "A-37",
+      "Dragon Fly"
+    ],
+    "tags": [
+      "Light Attack",
+      "CAS",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Light Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -920,7 +1184,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["bubble canopy", "compact airframe"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "compact airframe"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -939,10 +1206,33 @@
   },
   {
     "key": "A-29 Super Tucano",
-    "altNames": [],
-    "tags": ["Light Attack", "CAS", "Brazil"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Light Attack"],
+    "altNames": [
+      "A-29 Super Tucano",
+      "A-29",
+      "Super Tucano",
+      "Tucano"
+    ],
+    "tags": [
+      "Light Attack",
+      "CAS",
+      "Brazil"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Light Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1014,7 +1304,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["high-mounted wing", "tandem seating"]
+        "distinctiveFeatures": [
+          "high-mounted wing",
+          "tandem seating"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -1033,10 +1326,30 @@
   },
   {
     "key": "Alpha Jet",
-    "altNames": [""],
-    "tags": ["Trainer-Combat", "France", "Germany"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Trainer-Combat"],
+    "altNames": [
+      "Alpha Jet"
+    ],
+    "tags": [
+      "Trainer-Combat",
+      "France",
+      "Germany"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Trainer-Combat"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1108,7 +1421,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["bubble canopy", "high-mounted wing"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "high-mounted wing"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -1127,10 +1443,29 @@
   },
   {
     "key": "SF-260W",
-    "altNames": [""],
-    "tags": ["Trainer-Combat", "Italy"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Trainer-Combat"],
+    "altNames": [
+      "SF-260W"
+    ],
+    "tags": [
+      "Trainer-Combat",
+      "Italy"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Trainer-Combat"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1202,7 +1537,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["bubble canopy", "low-wing monoplane"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "low-wing monoplane"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -1221,10 +1559,35 @@
   },
   {
     "key": "F-14 Tomcat",
-    "altNames": ["F-14", "Tomcat"],
-    "tags": ["Air Superiority", "Interceptor", "Multirole", "USA", "Cold War"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "F-14 Tomcat",
+      "F-14",
+      "Tomcat"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Interceptor",
+      "Multirole",
+      "USA",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1296,7 +1659,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin tail fins", "bubble canopy"]
+        "distinctiveFeatures": [
+          "twin tail fins",
+          "bubble canopy"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -1315,10 +1681,38 @@
   },
   {
     "key": "F-15 Eagle",
-    "altNames": ["F-15, Eagle"],
-    "tags": ["Air Superiority", "Interceptor", "USA", "Cold War"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Fighter"],
+    "altNames": [
+      "F-15 Eagle",
+      "F-15",
+      "Eagle",
+      "F-15 Strike Eagle",
+      "F-15E Strike Eagle",
+      "F-15E",
+      "Strike Eagle"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Interceptor",
+      "USA",
+      "Cold War"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/xf6JJPX/87-0198-united-states-air-force-mcdonnell-douglas-f-15e-strike-eagle-Planespotters-Net-1578104-81abc.jpg",
+      "https://i.ibb.co/ZHhz9yY/90-0227-united-states-air-force-mcdonnell-douglas-f-15e-strike-eagle-Planespotters-Net-1603706-669d6.jpg",
+      "https://i.ibb.co/9Y6Wkww/91-0306-united-states-air-force-mcdonnell-douglas-f-15e-strike-eagle-Planespotters-Net-1651912-d7cb1.jpg",
+      "https://i.ibb.co/NTk9jwf/8221-republic-of-singapore-air-force-mcdonnell-douglas-f-15sg-f-15e-strike-eagle-Planespotters-Net-1.jpg",
+      "https://i.ibb.co/BLFR9Qb/02-009-republic-of-korea-air-force-rokaf-mcdonnell-douglas-f-15k-eagle-f-15e-strike-eagle-Planespott.jpg",
+      "https://i.ibb.co/f4CGN9B/86-0160-united-states-air-force-mcdonnell-douglas-f-15c-eagle-Planespotters-Net-1651514-b9eb1c7336-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/xf6JJPX/87-0198-united-states-air-force-mcdonnell-douglas-f-15e-strike-eagle-Planespotters-Net-1578104-81abc.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1390,7 +1784,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin tail fins", "bubble canopy"]
+        "distinctiveFeatures": [
+          "twin tail fins",
+          "bubble canopy"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -1409,10 +1806,37 @@
   },
   {
     "key": "F-16 Fighting Falcon",
-    "altNames": ["F-16, Fighting Falcon"],
-    "tags": ["Air Superiority", "Multirole", "USA", "Cold War", "Modern"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "F-16 Fighting Falcon",
+      "F-16",
+      "Fighting Falcon",
+      "Viper"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Multirole",
+      "USA",
+      "Cold War",
+      "Modern"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/Qf2DRWS/fa-86-belgian-air-force-general-dynamics-f-16am-fighting-falcon-Planespotters-Net-1231796-983db620f2.jpg",
+      "https://i.ibb.co/zRX2DCy/fa-101-belgian-air-force-sabca-f-16am-fighting-falcon-Planespotters-Net-1228386-a62896e556-o.jpg",
+      "https://i.ibb.co/1KfCZ44/88-0413-united-states-air-force-general-dynamics-f-16c-fighting-falcon-Planespotters-Net-1459756-f1a.jpg",
+      "https://i.ibb.co/m8g5fyd/88-0521-united-states-air-force-general-dynamics-f-16c-fighting-falcon-Planespotters-Net-1277543-2ae.jpg",
+      "https://i.ibb.co/vQ73MSD/88-0525-united-states-air-force-general-dynamics-f-16cm-fighting-falcon-401-Planespotters-Net-145499.jpg",
+      "https://i.ibb.co/JQwGKkr/4046-polish-air-force-general-dynamics-f-16c-fighting-falcon-Planespotters-Net-1492493-2357150fa8-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/1KfCZ44/88-0413-united-states-air-force-general-dynamics-f-16c-fighting-falcon-Planespotters-Net-1459756-f1a.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1484,7 +1908,10 @@
       },
       "fuselage": {
         "shape": "blended wing-body",
-        "distinctiveFeatures": ["bubble canopy", "blended wing-body design"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "blended wing-body design"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -1503,10 +1930,40 @@
   },
   {
     "key": "F/A-18 Hornet",
-    "altNames": ["F/A-18", "Hornet", "F-18 Hornet", "F-18"],
-    "tags": ["Multirole", "Air Superiority", "USA", "Carrier-Based"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "F/A-18 Hornet",
+      "F/A-18",
+      "Hornet",
+      "F-18 Hornet",
+      "F-18",
+      "F/A-18 Super Hornet",
+      "Super Hornet",
+      "F-18 Super Hornet"
+    ],
+    "tags": [
+      "Multirole",
+      "Air Superiority",
+      "USA",
+      "Carrier-Based"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/442MrBL/166448-united-states-navy-boeing-fa-18e-super-hornet-Planespotters-Net-1660560-668274132a-o.jpg",
+      "https://i.ibb.co/kcRL3fz/166599-united-states-navy-boeing-fa-18e-super-hornet-Planespotters-Net-1653203-2ef79f6131-o.jpg",
+      "https://i.ibb.co/VJVwZD1/169140-united-states-navy-boeing-ea-18g-growler-fa-18f-Planespotters-Net-1657910-89c4f055c6-o.jpg",
+      "https://i.ibb.co/R4fHn1R/a44-204-royal-australian-air-force-boeing-fa-18f-super-hornet-Planespotters-Net-1652346-f3dfdb9f9e-o.jpg",
+      "https://i.ibb.co/C8Xwh0x/hn-448-finnish-air-force-mcdonnell-douglas-fa-18c-hornet-Planespotters-Net-1410686-8a2f88f0c4-o.jpg",
+      "https://i.ibb.co/9swDBZQ/165919-united-states-navy-boeing-fa-18f-super-hornet-Planespotters-Net-1584469-004afb9eb1-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/VJVwZD1/169140-united-states-navy-boeing-ea-18g-growler-fa-18f-Planespotters-Net-1657910-89c4f055c6-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1578,7 +2035,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin vertical stabilizers", "leading-edge wing extensions"]
+        "distinctiveFeatures": [
+          "twin vertical stabilizers",
+          "leading-edge wing extensions"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -1597,10 +2057,35 @@
   },
   {
     "key": "F-22 Raptor",
-    "altNames": ["F-22", "Raptor"],
-    "tags": ["Air Superiority", "Stealth", "USA", "Modern"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Fighter"],
+    "altNames": [
+      "F-22 Raptor",
+      "F-22",
+      "Raptor",
+      "the kid",
+      "Franklin"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Stealth",
+      "USA",
+      "Modern"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/RzbKLHs/03-4061-united-states-air-force-lockheed-martin-f-22a-raptor-Planespotters-Net-1639888-0b5adaa52b-o.jpg",
+      "https://i.ibb.co/18Sy17m/04-4076-united-states-air-force-lockheed-martin-f-22a-raptor-Planespotters-Net-1118509-c3db5073b3-o.jpg",
+      "https://i.ibb.co/S7LqZJn/05-4104-united-states-air-force-lockheed-martin-f-22a-raptor-Planespotters-Net-1586713-a5fead64be-o.jpg",
+      "https://i.ibb.co/HNbrDxm/07-4138-united-states-air-force-lockheed-martin-f-22a-raptor-Planespotters-Net-1454373-65cfe845a3-o.jpg",
+      "https://i.ibb.co/dGn5HLz/08-4160-united-states-air-force-lockheed-martin-f-22a-raptor-Planespotters-Net-1499611-5886ee6609-o.jpg",
+      "https://i.ibb.co/pjGthnJ/08-4171-united-states-air-force-lockheed-martin-f-22a-raptor-Planespotters-Net-282370-177cf6aeb0-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/dGn5HLz/08-4160-united-states-air-force-lockheed-martin-f-22a-raptor-Planespotters-Net-1499611-5886ee6609-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1672,7 +2157,10 @@
       },
       "fuselage": {
         "shape": "stealth-optimized",
-        "distinctiveFeatures": ["internal weapons bays", "thrust-vectoring nozzles"]
+        "distinctiveFeatures": [
+          "internal weapons bays",
+          "thrust-vectoring nozzles"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -1691,10 +2179,36 @@
   },
   {
     "key": "F-35 Lightning II",
-    "altNames": ["F-35", "Lightning II", "Lighting"],
-    "tags": ["Multirole", "Stealth", "USA", "Modern"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "F-35 Lightning II",
+      "F-35",
+      "Lightning II",
+      "Lighting"
+    ],
+    "tags": [
+      "Multirole",
+      "Stealth",
+      "USA",
+      "Modern"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1766,7 +2280,10 @@
       },
       "fuselage": {
         "shape": "stealth-optimized",
-        "distinctiveFeatures": ["internal weapons bays", "stealth design"]
+        "distinctiveFeatures": [
+          "internal weapons bays",
+          "stealth design"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -1785,10 +2302,33 @@
   },
   {
     "key": "J-10 Jian",
-    "altNames": ["J-10", "Jian"],
-    "tags": ["Air Superiority", "Multirole", "China"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "J-10 Jian",
+      "J-10",
+      "Jian"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Multirole",
+      "China"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1860,7 +2400,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["canards", "delta wing"]
+        "distinctiveFeatures": [
+          "canards",
+          "delta wing"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -1879,10 +2422,33 @@
   },
   {
     "key": "JF-17 Thunder",
-    "altNames": ["JF-17", "Thunder"],
-    "tags": ["Multirole", "Pakistan", "China"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "JF-17 Thunder",
+      "JF-17",
+      "Thunder"
+    ],
+    "tags": [
+      "Multirole",
+      "Pakistan",
+      "China"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -1954,7 +2520,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["sharp nose", "bubble canopy"]
+        "distinctiveFeatures": [
+          "sharp nose",
+          "bubble canopy"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -1973,10 +2542,33 @@
   },
   {
     "key": "MiG-29 Fulcrum",
-    "altNames": ["MiG-29", "Fulcrum"],
-    "tags": ["Air Superiority", "Multirole", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "MiG-29 Fulcrum",
+      "MiG-29",
+      "Fulcrum"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Multirole",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2048,7 +2640,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin tail fins", "large air intakes"]
+        "distinctiveFeatures": [
+          "twin tail fins",
+          "large air intakes"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -2067,10 +2662,32 @@
   },
   {
     "key": "Mirage 5",
-    "altNames": ["Mirage III"],
-    "tags": ["Air Superiority", "France", "Multirole"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "Mirage 5",
+      "Mirage III"
+    ],
+    "tags": [
+      "Air Superiority",
+      "France",
+      "Multirole"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2142,7 +2759,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["pointed nose", "bubble canopy"]
+        "distinctiveFeatures": [
+          "pointed nose",
+          "bubble canopy"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -2161,10 +2781,31 @@
   },
   {
     "key": "Mirage F1",
-    "altNames": [""],
-    "tags": ["Air Superiority", "France", "Multirole"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "Mirage F1"
+    ],
+    "tags": [
+      "Air Superiority",
+      "France",
+      "Multirole"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2236,7 +2877,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["high-mounted swept wings", "slender fuselage"]
+        "distinctiveFeatures": [
+          "high-mounted swept wings",
+          "slender fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -2255,10 +2899,31 @@
   },
   {
     "key": "Mirage 2000",
-    "altNames": [""],
-    "tags": ["Air Superiority", "France", "Multirole"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "Mirage 2000"
+    ],
+    "tags": [
+      "Air Superiority",
+      "France",
+      "Multirole"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2330,7 +2995,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["delta wing design", "bubble canopy"]
+        "distinctiveFeatures": [
+          "delta wing design",
+          "bubble canopy"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -2349,10 +3017,33 @@
   },
   {
     "key": "Su-27 Flanker",
-    "altNames": ["Su-27, Flanker"],
-    "tags": ["Air Superiority", "Russia/USSR", "Multirole"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "Su-27 Flanker",
+      "Su-27",
+      "Flanker"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Russia/USSR",
+      "Multirole"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2424,7 +3115,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin vertical stabilizers", "large wingspan"]
+        "distinctiveFeatures": [
+          "twin vertical stabilizers",
+          "large wingspan"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -2443,10 +3137,33 @@
   },
   {
     "key": "JAS 39 Gripen",
-    "altNames": ["JAS 39, Gripen"],
-    "tags": ["Multirole", "Sweden", "Air Superiority"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "JAS 39 Gripen",
+      "JAS 39",
+      "Gripen"
+    ],
+    "tags": [
+      "Multirole",
+      "Sweden",
+      "Air Superiority"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2518,7 +3235,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["delta wing design", "canards for maneuverability"]
+        "distinctiveFeatures": [
+          "delta wing design",
+          "canards for maneuverability"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -2537,10 +3257,36 @@
   },
   {
     "key": "Eurofighter Typhoon",
-    "altNames": ["Eurofighter", "Typhoon"],
-    "tags": ["Air Superiority", "Multirole", "UK", "Germany", "Italy", "Spain"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "Eurofighter Typhoon",
+      "Eurofighter",
+      "Typhoon"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Multirole",
+      "UK",
+      "Germany",
+      "Italy",
+      "Spain"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2612,7 +3358,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["canards", "delta wing"]
+        "distinctiveFeatures": [
+          "canards",
+          "delta wing"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -2631,10 +3380,33 @@
   },
   {
     "key": "MiG-15 Fagot",
-    "altNames": ["MiG-15", "Fagot"],
-    "tags": ["Air Superiority", "Interceptor", "Russia/USSR"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Fighter"],
+    "altNames": [
+      "MiG-15 Fagot",
+      "MiG-15",
+      "Fagot"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Interceptor",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2706,7 +3478,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["bubble canopy", "swept-back wings"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "swept-back wings"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -2725,10 +3500,33 @@
   },
   {
     "key": "MiG-17 Fresco",
-    "altNames": ["MiG-17, Fresco"],
-    "tags": ["Air Superiority", "Interceptor", "Russia/USSR"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Fighter"],
+    "altNames": [
+      "MiG-17 Fresco",
+      "MiG-17",
+      "Fresco"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Interceptor",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2800,7 +3598,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["swept-wing design", "elongated fuselage"]
+        "distinctiveFeatures": [
+          "swept-wing design",
+          "elongated fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -2819,10 +3620,32 @@
   },
   {
     "key": "MiG-19 Farmer",
-    "altNames": ["MiG-19", "Farmer"],
-    "tags": ["Air Superiority", "Interceptor", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter"],
+    "altNames": [
+      "MiG-19 Farmer",
+      "MiG-19",
+      "Farmer"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Interceptor",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2894,7 +3717,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin-engine configuration", "bubble canopy"]
+        "distinctiveFeatures": [
+          "twin-engine configuration",
+          "bubble canopy"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -2913,10 +3739,32 @@
   },
   {
     "key": "MiG-21 Fishbed",
-    "altNames": ["MiG-21", "Fishbed"],
-    "tags": ["Air Superiority", "Interceptor", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter"],
+    "altNames": [
+      "MiG-21 Fishbed",
+      "MiG-21",
+      "Fishbed"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Interceptor",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -2988,7 +3836,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["sharp nose", "prominent air intake"]
+        "distinctiveFeatures": [
+          "sharp nose",
+          "prominent air intake"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -3007,10 +3858,32 @@
   },
   {
     "key": "MiG-25 Foxbat",
-    "altNames": ["MiG-25", "Foxbat"],
-    "tags": ["Interceptor", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Reconnaissance"],
+    "altNames": [
+      "MiG-25 Foxbat",
+      "MiG-25",
+      "Foxbat"
+    ],
+    "tags": [
+      "Interceptor",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Reconnaissance"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3082,7 +3955,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["large air intakes", "twin vertical stabilizers"]
+        "distinctiveFeatures": [
+          "large air intakes",
+          "twin vertical stabilizers"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -3101,10 +3977,33 @@
   },
   {
     "key": "MiG-27 Flogger",
-    "altNames": ["MiG-27", "Flogger"],
-    "tags": ["Ground Attack", "Fighter Bomber", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Attack", "Fighter-Bomber"],
+    "altNames": [
+      "MiG-27 Flogger",
+      "MiG-27",
+      "Flogger"
+    ],
+    "tags": [
+      "Ground Attack",
+      "Fighter Bomber",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Attack",
+      "Fighter-Bomber"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3176,7 +4075,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["reinforced nose for ground attack", "tail buoy"]
+        "distinctiveFeatures": [
+          "reinforced nose for ground attack",
+          "tail buoy"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -3195,10 +4097,32 @@
   },
   {
     "key": "MiG-31 Foxhound",
-    "altNames": ["MiG-31", "Foxhound"],
-    "tags": ["Air Superiority", "Interceptor", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Interceptor"],
+    "altNames": [
+      "MiG-31",
+      "Foxhound"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Interceptor",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Interceptor"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3270,7 +4194,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin-engine configuration", "twin vertical stabilizers"]
+        "distinctiveFeatures": [
+          "twin-engine configuration",
+          "twin vertical stabilizers"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -3289,10 +4216,34 @@
   },
   {
     "key": "Su-57 Felon",
-    "altNames": ["Su-57", "Felon"],
-    "tags": ["Air Superiority", "Multirole", "Stealth", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "Su-57 Felon",
+      "Su-57",
+      "Felon"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Multirole",
+      "Stealth",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3364,7 +4315,10 @@
       },
       "fuselage": {
         "shape": "sleek",
-        "distinctiveFeatures": ["stealth design", "internal weapon bays"]
+        "distinctiveFeatures": [
+          "stealth design",
+          "internal weapon bays"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -3383,10 +4337,33 @@
   },
   {
     "key": "J-20 Fagin",
-    "altNames": ["J-20", "Fagin"],
-    "tags": ["Air Superiority", "Stealth", "China"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Fighter", "Multirole"],
+    "altNames": [
+      "J-20 Fagin",
+      "J-20",
+      "Fagin"
+    ],
+    "tags": [
+      "Air Superiority",
+      "Stealth",
+      "China"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Fighter",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3458,7 +4435,11 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["stealth design", "long fuselage", "canard foreplanes"]
+        "distinctiveFeatures": [
+          "stealth design",
+          "long fuselage",
+          "canard foreplanes"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -3477,10 +4458,32 @@
   },
   {
     "key": "B-1B Lancer",
-    "altNames": ["B-1B", "Lancer", "B1"],
-    "tags": ["Bomber", "USA", "Cold War"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Bomber"],
+    "altNames": [
+      "B-1B",
+      "Lancer",
+      "B1"
+    ],
+    "tags": [
+      "Bomber",
+      "USA",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Bomber"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3552,7 +4555,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["large bomb bays", "variable-sweep wing configuration"]
+        "distinctiveFeatures": [
+          "large bomb bays",
+          "variable-sweep wing configuration"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -3571,10 +4577,34 @@
   },
   {
     "key": "B-2 Spirit",
-    "altNames": ["B-2", "Spirit"],
-    "tags": ["Bomber", "Stealth", "USA", "Modern"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Bomber", "Stealth"],
+    "altNames": [
+      "B-2 Spirit",
+      "B-2",
+      "Spirit"
+    ],
+    "tags": [
+      "Bomber",
+      "Stealth",
+      "USA",
+      "Modern"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Bomber",
+      "Stealth"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3646,7 +4676,10 @@
       },
       "fuselage": {
         "shape": "flying wing",
-        "distinctiveFeatures": ["no vertical stabilizers", "stealth optimized"]
+        "distinctiveFeatures": [
+          "no vertical stabilizers",
+          "stealth optimized"
+        ]
       },
       "tail": {
         "type": "none",
@@ -3665,10 +4698,33 @@
   },
   {
     "key": "B-52 Stratofortress",
-    "altNames": ["B-52", "Stratofortress"],
-    "tags": ["Bomber", "USA", "Cold War"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Bomber"],
+    "altNames": [
+      "B-52 Stratofortress",
+      "B-52",
+      "Stratofortress",
+      "Buff"
+    ],
+    "tags": [
+      "Bomber",
+      "USA",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Bomber"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3740,7 +4796,10 @@
       },
       "fuselage": {
         "shape": "long cylindrical",
-        "distinctiveFeatures": ["large bomb bays", "tandem cockpit"]
+        "distinctiveFeatures": [
+          "large bomb bays",
+          "tandem cockpit"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -3759,10 +4818,33 @@
   },
   {
     "key": "Tu-95 Bear",
-    "altNames": ["Tu-95", "Bear"],
-    "tags": ["Bomber", "Russia/USSR", "Cold War"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Bomber"],
+    "altNames": [
+      "Tu-95 Bear",
+      "Tu-95",
+      "Bear"
+    ],
+    "tags": [
+      "Bomber",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Bomber"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3834,7 +4916,10 @@
       },
       "fuselage": {
         "shape": "long cylindrical",
-        "distinctiveFeatures": ["tandem cockpit", "tail gunner position"]
+        "distinctiveFeatures": [
+          "tandem cockpit",
+          "tail gunner position"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -3853,10 +4938,33 @@
   },
   {
     "key": "Tu-160 Blackjack",
-    "altNames": ["Tu-160", "Blackjack"],
-    "tags": ["Bomber", "Russia/USSR", "Cold War"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Bomber"],
+    "altNames": [
+      "Tu-160 Blackjack",
+      "Tu-160",
+      "Blackjack"
+    ],
+    "tags": [
+      "Bomber",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Bomber"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -3951,10 +5059,32 @@
   },
   {
     "key": "Tu-22M Backfire",
-    "altNames": ["Tu-22M", "Backfire"],
-    "tags": ["Bomber", "Russia/USSR", "Cold War"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Bomber"],
+    "altNames": [
+      "Tu-22M Backfire",
+      "Tu-22M",
+      "Backfire"
+    ],
+    "tags": [
+      "Bomber",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Bomber"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4026,7 +5156,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["large internal bomb bays", "twin-engine design"]
+        "distinctiveFeatures": [
+          "large internal bomb bays",
+          "twin-engine design"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -4045,10 +5178,32 @@
   },
   {
     "key": "An-124 Condor",
-    "altNames": ["An-124", "Condor"],
-    "tags": ["Transport", "Russia/USSR", "Cold War"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "An-124 Condor",
+      "An-124",
+      "Condor"
+    ],
+    "tags": [
+      "Transport",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/fDsrtv2/ur-82027-antonov-airlines-antonov-an-124-100-Planespotters-Net-087679-134926f422-o.jpg",
+      "https://i.ibb.co/Vmb97jC/ur-82027-antonov-airlines-antonov-an-124-100m-Planespotters-Net-1641257-179173f2bc-o.jpg",
+      "https://i.ibb.co/sbGYTXV/ur-82072-antonov-airlines-antonov-an-124-100-150-Planespotters-Net-1432259-f1971aadd2-o.jpg",
+      "https://i.ibb.co/j8Hqp5j/ur-82073-antonov-airlines-antonov-an-124-100-Planespotters-Net-1420941-50c819b37f-o.jpg",
+      "https://i.ibb.co/B6dVKZZ/ra-82044-volga-dnepr-antonov-an-124-100-Planespotters-Net-1665756-53bcebbb50-o.jpg",
+      "https://i.ibb.co/TMVhftt/ur-82007-antonov-airlines-antonov-an-124-100m-Planespotters-Net-1649031-27e7860df7-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/TMVhftt/ur-82007-antonov-airlines-antonov-an-124-100m-Planespotters-Net-1649031-27e7860df7-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4120,7 +5275,10 @@
       },
       "fuselage": {
         "shape": "bulky",
-        "distinctiveFeatures": ["large cargo hold", "nose section can be raised for loading"]
+        "distinctiveFeatures": [
+          "large cargo hold",
+          "nose section can be raised for loading"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -4139,10 +5297,32 @@
   },
   {
     "key": "C-5 Galaxy",
-    "altNames": ["C-5", "Galaxy"],
-    "tags": ["Transport", "USA", "Cold War"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "C-5 Galaxy",
+      "C-5",
+      "Galaxy"
+    ],
+    "tags": [
+      "Transport",
+      "USA",
+      "Cold War"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/njMGkvP/85-0007-united-states-air-force-lockheed-c-5m-super-galaxy-l-500-Planespotters-Net-1643356-d16d6e469.jpg",
+      "https://i.ibb.co/vBy9hM6/86-0018-united-states-air-force-lockheed-c-5m-super-galaxy-l-500-Planespotters-Net-1379509-5a16196ba.jpg",
+      "https://i.ibb.co/7V2QJVW/86-0026-united-states-air-force-lockheed-c-5m-super-galaxy-l-500-Planespotters-Net-1542257-0709f37fd.jpg",
+      "https://i.ibb.co/8BWSzJm/87-0028-united-states-air-force-lockheed-c-5m-super-galaxy-l-500-Planespotters-Net-1562360-d9050e5c4.jpg",
+      "https://i.ibb.co/5v2N5rb/69-0021-united-states-air-force-lockheed-c-5a-galaxy-l-500-Planespotters-Net-175829-060ff07cea-o.jpg",
+      "https://i.ibb.co/JQY8GVx/84-0062-united-states-air-force-lockheed-c-5m-super-galaxy-l-500-Planespotters-Net-1661558-19d5452d0.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/8BWSzJm/87-0028-united-states-air-force-lockheed-c-5m-super-galaxy-l-500-Planespotters-Net-1562360-d9050e5c4.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4214,7 +5394,11 @@
       },
       "fuselage": {
         "shape": "bulky",
-        "distinctiveFeatures": ["large cargo hold", "tail makes a capital 'T' shape", "no winglets"]
+        "distinctiveFeatures": [
+          "large cargo hold",
+          "tail makes a capital 'T' shape",
+          "no winglets"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -4233,10 +5417,33 @@
   },
   {
     "key": "An-12 Cub",
-    "altNames": [""],
-    "tags": ["Transport", "Russia/USSR", "Cold War"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "An-12 Cub",
+      "An-12",
+      "Cub"
+    ],
+    "tags": [
+      "Transport",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4308,7 +5515,10 @@
       },
       "fuselage": {
         "shape": "cylindrical",
-        "distinctiveFeatures": ["large rear cargo door", "high-mounted wings"]
+        "distinctiveFeatures": [
+          "large rear cargo door",
+          "high-mounted wings"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -4327,10 +5537,34 @@
   },
   {
     "key": "C-17 Globemaster III",
-    "altNames": ["C-17", "Globemaster III", "C-17 Globemaster", "Globemaster"],
-    "tags": ["Transport", "USA", "Modern"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "C-17 Globemaster III",
+      "C-17",
+      "Globemaster III",
+      "C-17 Globemaster",
+      "Globemaster"
+    ],
+    "tags": [
+      "Transport",
+      "USA",
+      "Modern"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/GsPK8pw/96-0002-united-states-air-force-boeing-c-17a-globemaster-iii-Planespotters-Net-1495344-714e8e0280-o.jpg",
+      "https://i.ibb.co/dKP2DpB/96-0005-united-states-air-force-boeing-c-17a-globemaster-iii-Planespotters-Net-1627632-81cc844915-o.jpg",
+      "https://i.ibb.co/TtMDgBm/kaf-342-kuwait-air-force-boeing-c-17a-globemaster-iii-Planespotters-Net-1596264-2ebf057436-o.jpg",
+      "https://i.ibb.co/LzNvzng/zz178-royal-air-force-boeing-c-17a-globemaster-iii-Planespotters-Net-286549-2787ce9869-o.jpg",
+      "https://i.ibb.co/W57cK9Q/04-4130-united-states-air-force-boeing-c-17a-globemaster-iii-Planespotters-Net-1584323-3e498aefb8-o.jpg",
+      "https://i.ibb.co/ZzgGVWw/07-7188-united-states-air-force-boeing-c-17a-globemaster-iii-Planespotters-Net-1119998-27b127112f-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/LzNvzng/zz178-royal-air-force-boeing-c-17a-globemaster-iii-Planespotters-Net-286549-2787ce9869-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4402,7 +5636,10 @@
       },
       "fuselage": {
         "shape": "bulky",
-        "distinctiveFeatures": ["large rear cargo ramp", "high-mounted wings"]
+        "distinctiveFeatures": [
+          "large rear cargo ramp",
+          "high-mounted wings"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -4421,10 +5658,36 @@
   },
   {
     "key": "C-130 Hercules",
-    "altNames": ["C-130", "Hercules", "C-130J", "Super Hercules"],
-    "tags": ["Transport", "USA", "Cold War", "Modern"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "C-130 Hercules",
+      "C-130",
+      "Hercules",
+      "C-130J",
+      "Super Hercules"
+    ],
+    "tags": [
+      "Transport",
+      "USA",
+      "Cold War",
+      "Modern"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/nzWSFyk/98-5307-united-states-air-force-lockheed-martin-wc-130j-Planespotters-Net-1586811-e009211e99-o.jpg",
+      "https://i.ibb.co/9hrf3wN/98-5308-united-states-air-force-lockheed-martin-wc-130j-Planespotters-Net-1606990-9fa11c1e59-o.jpg",
+      "https://i.ibb.co/KWLNpCm/ch-01-belgian-air-force-lockheed-c-130h-hercules-l-382-Planespotters-Net-1185859-1e9d1c656e-o.jpg",
+      "https://i.ibb.co/XXk0MJQ/n2679c-tepper-aviation-lockheed-l-100-30-hercules-l-382g-Planespotters-Net-1670157-2ef0f0b851-o.jpg",
+      "https://i.ibb.co/DwMJ6yc/05-186-republic-of-korea-air-force-rokaf-lockheed-c-130h-hercules-l-382-Planespotters-Net-1670202-83.jpg",
+      "https://i.ibb.co/BqjSxft/18-5882-united-states-air-force-lockheed-martin-ac-130j-ghostrider-Planespotters-Net-1552285-82a3c84.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/DwMJ6yc/05-186-republic-of-korea-air-force-rokaf-lockheed-c-130h-hercules-l-382-Planespotters-Net-1670202-83.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4496,7 +5759,10 @@
       },
       "fuselage": {
         "shape": "cylindrical",
-        "distinctiveFeatures": ["large rear cargo door", "high-mounted wings"]
+        "distinctiveFeatures": [
+          "large rear cargo door",
+          "high-mounted wings"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -4515,10 +5781,32 @@
   },
   {
     "key": "C-160 Transall",
-    "altNames": ["C-160", "Transall"],
-    "tags": ["Transport", "Germany", "Cold War"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "C-160 Transall",
+      "C-160",
+      "Transall"
+    ],
+    "tags": [
+      "Transport",
+      "Germany",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4590,7 +5878,10 @@
       },
       "fuselage": {
         "shape": "cylindrical",
-        "distinctiveFeatures": ["rear cargo door", "high-mounted wings"]
+        "distinctiveFeatures": [
+          "rear cargo door",
+          "high-mounted wings"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -4609,10 +5900,32 @@
   },
   {
     "key": "IL-76 Candid",
-    "altNames": ["IL-76", "Candid"],
-    "tags": ["Transport", "Russia/USSR", "Cold War"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "IL-76 Candid",
+      "IL-76",
+      "Candid"
+    ],
+    "tags": [
+      "Transport",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4684,7 +5997,10 @@
       },
       "fuselage": {
         "shape": "cylindrical",
-        "distinctiveFeatures": ["large rear cargo door", "high-mounted wings"]
+        "distinctiveFeatures": [
+          "large rear cargo door",
+          "high-mounted wings"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -4703,10 +6019,32 @@
   },
   {
     "key": "An-72 Coaler",
-    "altNames": ["An-72", "Coaler"],
-    "tags": ["Transport", "Russia/USSR", "Cold War"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "An-72 Coaler",
+      "An-72",
+      "Coaler"
+    ],
+    "tags": [
+      "Transport",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4778,7 +6116,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["upward tilt for STOL", "raised rear cargo ramp"]
+        "distinctiveFeatures": [
+          "upward tilt for STOL",
+          "raised rear cargo ramp"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -4797,10 +6138,32 @@
   },
   {
     "key": "C-212 Aviocar",
-    "altNames": ["C-212", "Aviocar"],
-    "tags": ["Transport", "Light Cargo", "Spain"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "C-212 Aviocar",
+      "C-212",
+      "Aviocar"
+    ],
+    "tags": [
+      "Transport",
+      "Light Cargo",
+      "Spain"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4872,7 +6235,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["large cargo door", "high-mounted wings"]
+        "distinctiveFeatures": [
+          "large cargo door",
+          "high-mounted wings"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -4891,10 +6257,32 @@
   },
   {
     "key": "C-23 Sherpa",
-    "altNames": ["C-23, Sherpa"],
-    "tags": ["Transport", "Light Cargo", "USA"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "C-23 Sherpa",
+      "C-23",
+      "Sherpa"
+    ],
+    "tags": [
+      "Transport",
+      "Light Cargo",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -4966,7 +6354,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["rear loading ramp", "high-mounted wings"]
+        "distinctiveFeatures": [
+          "rear loading ramp",
+          "high-mounted wings"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -4985,10 +6376,32 @@
   },
   {
     "key": "AN-26 Curl",
-    "altNames": ["AN-26", "Curl"],
-    "tags": ["Transport", "Cargo", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "AN-26 Curl",
+      "AN-26",
+      "Curl"
+    ],
+    "tags": [
+      "Transport",
+      "Cargo",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5060,7 +6473,10 @@
       },
       "fuselage": {
         "shape": "cylindrical",
-        "distinctiveFeatures": ["rugged fuselage", "rear cargo door"]
+        "distinctiveFeatures": [
+          "rugged fuselage",
+          "rear cargo door"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -5079,10 +6495,32 @@
   },
   {
     "key": "AN-32 Cline",
-    "altNames": ["AN-32", "Cline"],
-    "tags": ["Transport", "Cargo", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "AN-32 Cline",
+      "AN-32",
+      "Cline"
+    ],
+    "tags": [
+      "Transport",
+      "Cargo",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5176,10 +6614,32 @@
   },
   {
     "key": "AH-1 Cobra",
-    "altNames": ["AH-1", "Cobra"],
-    "tags": ["Attack Helicopter", "USA", "Cold War"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Attack Helicopter"],
+    "altNames": [
+      "AH-1 Cobra",
+      "AH-1",
+      "Cobra"
+    ],
+    "tags": [
+      "Attack Helicopter",
+      "USA",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Attack Helicopter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5251,7 +6711,10 @@
       },
       "fuselage": {
         "shape": "narrow",
-        "distinctiveFeatures": ["tandem seating", "nose-mounted weapons"]
+        "distinctiveFeatures": [
+          "tandem seating",
+          "nose-mounted weapons"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -5270,10 +6733,33 @@
   },
   {
     "key": "AH-64 Apache",
-    "altNames": ["AH-64", "Apache"],
-    "tags": ["Attack Helicopter", "USA", "Modern"],
-    "hltag": ["devtest"],
-    "accat": ["Rotor-Wing", "Attack Helicopter"],
+    "altNames": [
+      "AH-64 Apache",
+      "AH-64",
+      "Apache"
+    ],
+    "tags": [
+      "Attack Helicopter",
+      "USA",
+      "Modern"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Attack Helicopter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5345,7 +6831,10 @@
       },
       "fuselage": {
         "shape": "armored",
-        "distinctiveFeatures": ["tandem seating", "large, four-blade rotor system"]
+        "distinctiveFeatures": [
+          "tandem seating",
+          "large, four-blade rotor system"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -5364,10 +6853,37 @@
   },
   {
     "key": "Ka-50/52 Hokum A/B",
-    "altNames": ["Ka-50 Hokum A", "Ka-52 Hokum B", "Ka-50A", "Ka-50", "Ka-52", "Ka-52B", "Hokum"],
-    "tags": ["Attack Helicopter", "Russia/USSR", "Modern"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Attack Helicopter"],
+    "altNames": [
+      "Ka-50/52 Hokum A/B",
+      "Ka-50 Hokum A",
+      "Ka-52 Hokum B",
+      "Ka-50A",
+      "Ka-50",
+      "Ka-52",
+      "Ka-52B",
+      "Hokum"
+    ],
+    "tags": [
+      "Attack Helicopter",
+      "Russia/USSR",
+      "Modern"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Attack Helicopter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5439,7 +6955,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["tandem seating", "heavily armored fuselage"]
+        "distinctiveFeatures": [
+          "tandem seating",
+          "heavily armored fuselage"
+        ]
       },
       "tail": {
         "type": "none (coaxial)",
@@ -5458,10 +6977,34 @@
   },
   {
     "key": "Mi-24 Hind",
-    "altNames": ["Mi-24", "Hind"],
-    "tags": ["Attack Helicopter", "Transport", "Russia/USSR", "Cold War"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Attack Helicopter", "Transport"],
+    "altNames": [
+      "Mi-24 Hind",
+      "Mi-24",
+      "Hind"
+    ],
+    "tags": [
+      "Attack Helicopter",
+      "Transport",
+      "Russia/USSR",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Attack Helicopter",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5533,7 +7076,10 @@
       },
       "fuselage": {
         "shape": "large, armored",
-        "distinctiveFeatures": ["tandem cockpit", "troop-carrying capacity"]
+        "distinctiveFeatures": [
+          "tandem cockpit",
+          "troop-carrying capacity"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -5552,10 +7098,32 @@
   },
   {
     "key": "Mi-28 Havoc",
-    "altNames": ["Mi-28", "Havoc"],
-    "tags": ["Attack Helicopter", "Russia/USSR", "Modern"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Attack Helicopter"],
+    "altNames": [
+      "Mi-28 Havoc",
+      "Mi-28",
+      "Havoc"
+    ],
+    "tags": [
+      "Attack Helicopter",
+      "Russia/USSR",
+      "Modern"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Attack Helicopter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5627,7 +7195,10 @@
       },
       "fuselage": {
         "shape": "armored, streamlined",
-        "distinctiveFeatures": ["tandem cockpit", "chin-mounted cannon"]
+        "distinctiveFeatures": [
+          "tandem cockpit",
+          "chin-mounted cannon"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -5646,10 +7217,32 @@
   },
   {
     "key": "A129 Mangusta",
-    "altNames": ["A129", "Mangusta"],
-    "tags": ["Attack Helicopter", "Italy"],
-    "hltag": ["devtest"],
-    "accat": ["Rotor-Wing", "Attack Helicopter"],
+    "altNames": [
+      "A129 Mangusta",
+      "A129",
+      "Mangusta"
+    ],
+    "tags": [
+      "Attack Helicopter",
+      "Italy"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Attack Helicopter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5721,7 +7314,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["tandem cockpit", "narrow airframe"]
+        "distinctiveFeatures": [
+          "tandem cockpit",
+          "narrow airframe"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -5740,10 +7336,33 @@
   },
   {
     "key": "Ec-665 Tiger",
-    "altNames": ["Ec-665", "Tiger"],
-    "tags": ["Attack Helicopter", "France", "Germany", "Modern"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Attack Helicopter"],
+    "altNames": [
+      "Ec-665 Tiger",
+      "Ec-665",
+      "Tiger"
+    ],
+    "tags": [
+      "Attack Helicopter",
+      "France",
+      "Germany",
+      "Modern"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Attack Helicopter"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5815,7 +7434,10 @@
       },
       "fuselage": {
         "shape": "narrow, streamlined",
-        "distinctiveFeatures": ["tandem seating", "four-blade rotor system"]
+        "distinctiveFeatures": [
+          "tandem seating",
+          "four-blade rotor system"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -5834,10 +7456,32 @@
   },
   {
     "key": "CH-47 Chinook",
-    "altNames": ["CH-47", "Chinook"],
-    "tags": ["Utility Helicopter", "Heavy-Lift", "USA"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Heavy-Lift"],
+    "altNames": [
+      "CH-47 Chinook",
+      "CH-47",
+      "Chinook"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Heavy-Lift",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Heavy-Lift"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -5909,7 +7553,10 @@
       },
       "fuselage": {
         "shape": "long, cylindrical",
-        "distinctiveFeatures": ["tandem rotors", "rear loading ramp"]
+        "distinctiveFeatures": [
+          "tandem rotors",
+          "rear loading ramp"
+        ]
       },
       "tail": {
         "type": "no tail rotor",
@@ -5928,10 +7575,32 @@
   },
   {
     "key": "CH-53 Sea Stallion",
-    "altNames": ["CH-53", "Sea Stallion"],
-    "tags": ["Utility Helicopter", "Heavy-Lift", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Heavy-Lift"],
+    "altNames": [
+      "CH-53 Sea Stallion",
+      "CH-53",
+      "Sea Stallion"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Heavy-Lift",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/PCPpbqk/162479-united-states-marine-corps-sikorsky-ch-53a-Planespotters-Net-219288-f248f14937-o.jpg",
+      "https://i.ibb.co/vQqZjRT/164366-united-states-marine-corps-sikorsky-ch-53a-Planespotters-Net-218257-c9d626112e-o.jpg",
+      "https://i.ibb.co/MpR0H3N/164366-united-states-marine-corps-sikorsky-ch-53a-Planespotters-Net-221275-322df4ff6e-o.jpg",
+      "https://i.ibb.co/k1ZVrSv/164366-united-states-marine-corps-sikorsky-ch-53a-Planespotters-Net-239491-9e2a694099-o.jpg",
+      "https://i.ibb.co/FHxgxQH/8441-german-army-sikorsky-ch-53g-Planespotters-Net-101079-17b0911100-o.jpg",
+      "https://i.ibb.co/x5b4dy6/162479-united-states-marine-corps-sikorsky-ch-53a-Planespotters-Net-218256-b54a0b20b8-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/k1ZVrSv/164366-united-states-marine-corps-sikorsky-ch-53a-Planespotters-Net-239491-9e2a694099-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Heavy-Lift"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6003,7 +7672,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["rear loading ramp", "large cargo hold"]
+        "distinctiveFeatures": [
+          "rear loading ramp",
+          "large cargo hold"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6023,10 +7695,33 @@
   },
   {
     "key": "UH-60 Black Hawk",
-    "altNames": ["UH-60", "Black Hawk"],
-    "tags": ["Utility Helicopter", "USA", "Modern"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "UH-60 Black Hawk",
+      "UH-60",
+      "Black Hawk"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "USA",
+      "Modern"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/k90FhJB/7445-slovak-air-force-sikorsky-uh-60m-black-hawk-Planespotters-Net-1482894-736a8dc93d-o.jpg",
+      "https://i.ibb.co/RQWcwb8/07-20074-united-states-army-sikorsky-uh-60m-black-hawk-Planespotters-Net-1651192-64c84a1a77-o.jpg",
+      "https://i.ibb.co/yV5nf0H/26-573-united-states-army-sikorsky-uh-60-black-hawk-Planespotters-Net-240549-1698d88a62-o.jpg",
+      "https://i.ibb.co/9czxdSR/20-21118-united-states-army-sikorsky-uh-60m-black-hawk-Planespotters-Net-1435603-ce1907ba68-o.jpg",
+      "https://i.ibb.co/ssQN5ZT/88-26027-united-states-air-force-sikorsky-uh-60-black-hawk-Planespotters-Net-667601-c08961ee3e-o.jpg",
+      "https://i.ibb.co/wzVqFgp/232-croatian-air-force-sikorsky-uh-60m-black-hawk-Planespotters-Net-1549142-a2138af185-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/yV5nf0H/26-573-united-states-army-sikorsky-uh-60-black-hawk-Planespotters-Net-240549-1698d88a62-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6098,7 +7793,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["four-blade rotor", "rear loading ramp"]
+        "distinctiveFeatures": [
+          "four-blade rotor",
+          "rear loading ramp"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6118,10 +7816,31 @@
   },
   {
     "key": "UH-72 Lakota",
-    "altNames": ["UH-72", "Lakota"],
-    "tags": ["Utility Helicopter", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "UH-72 Lakota",
+      "UH-72",
+      "Lakota"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/30s36DH/07-72029-united-states-army-eurocopter-uh-72a-lakota-Planespotters-Net-1218809-b34f14af6e-o.jpg",
+      "https://i.ibb.co/9V4qKy2/08-72060-united-states-army-eurocopter-uh-72a-lakota-Planespotters-Net-1643264-db23753d36-o.jpg",
+      "https://i.ibb.co/bb5rypn/08-72068-united-states-army-eurocopter-uh-72a-lakota-Planespotters-Net-1440169-dce3300f70-o.jpg",
+      "https://i.ibb.co/7pC6m1j/09-72107-united-states-army-eurocopter-uh-72a-lakota-Planespotters-Net-1206022-0746f1646d-o.jpg",
+      "https://i.ibb.co/NC2pnh5/11-72208-united-states-army-eurocopter-uh-72a-lakota-Planespotters-Net-1339714-5ee656f30c-o.jpg",
+      "https://i.ibb.co/hMbd7Kq/12-72266-united-states-army-uh-72a-Planespotters-Net-1530830-f214ceaac6-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/bb5rypn/08-72068-united-states-army-eurocopter-uh-72a-lakota-Planespotters-Net-1440169-dce3300f70-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6193,7 +7912,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["small cabin", "twin engines"]
+        "distinctiveFeatures": [
+          "small cabin",
+          "twin engines"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6213,10 +7935,33 @@
   },
   {
     "key": "Mi-8 Hip",
-    "altNames": ["Mi-8", "Hip"],
-    "tags": ["Utility Helicopter", "Transport", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Utility", "Transport"],
+    "altNames": [
+      "Mi-8 Hip",
+      "Mi-8",
+      "Hip"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Transport",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6288,7 +8033,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["rear loading ramp", "five-blade rotor"]
+        "distinctiveFeatures": [
+          "rear loading ramp",
+          "five-blade rotor"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6308,10 +8056,32 @@
   },
   {
     "key": "Mi-26 Halo",
-    "altNames": ["Mi-26", "Halo"],
-    "tags": ["Heavy-Lift", "Utility Helicopter", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Heavy-Lift"],
+    "altNames": [
+      "Mi-26 Halo",
+      "Mi-26",
+      "Halo"
+    ],
+    "tags": [
+      "Heavy-Lift",
+      "Utility Helicopter",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Heavy-Lift"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6383,7 +8153,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["eight-blade rotor", "large fuselage"]
+        "distinctiveFeatures": [
+          "eight-blade rotor",
+          "large fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6403,10 +8176,32 @@
   },
   {
     "key": "NH-90",
-    "altNames": [""],
-    "tags": ["Utility Helicopter", "Transport", "Germany", "France"],
-    "hltag": ["devtest"],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "NH-90"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Transport",
+      "Germany",
+      "France"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6478,7 +8273,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["medium-sized cabin", "four-blade rotor"]
+        "distinctiveFeatures": [
+          "medium-sized cabin",
+          "four-blade rotor"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6498,10 +8296,34 @@
   },
   {
     "key": "SA-316/SA-319 Alouette III",
-    "altNames": ["SA-319 Alouette III", "SA-316 Alouette III", "SA-319", "SA-316", "Alouette III"],
-    "tags": ["Utility Helicopter", "France"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "SA-316/SA-319 Alouette III",
+      "SA-319 Alouette III",
+      "SA-316 Alouette III",
+      "SA-319",
+      "SA-316",
+      "Alouette III"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "France"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6573,7 +8395,10 @@
       },
       "fuselage": {
         "shape": "slender",
-        "distinctiveFeatures": ["glass cockpit", "three-blade rotor"]
+        "distinctiveFeatures": [
+          "glass cockpit",
+          "three-blade rotor"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6593,10 +8418,35 @@
   },
   {
     "key": "AS332/AS532 Super Puma/Cougar",
-    "altNames": ["AS332", "AS532", "AS332 Super Puma", "Super Puma", "AS532 Cougar", "Cougar"],
-    "tags": ["Utility Helicopter", "France"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "AS332/AS532 Super Puma/Cougar",
+      "AS332",
+      "AS532",
+      "AS332 Super Puma",
+      "Super Puma",
+      "AS532 Cougar",
+      "Cougar"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "France"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6668,7 +8518,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["high-mounted tail boom", "large cabin"]
+        "distinctiveFeatures": [
+          "high-mounted tail boom",
+          "large cabin"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6688,10 +8541,31 @@
   },
   {
     "key": "SA-330 Puma",
-    "altNames": ["SA-330", "Puma"],
-    "tags": ["Utility Helicopter", "France"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "SA-330 Puma",
+      "SA-330",
+      "Puma"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "France"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6763,7 +8637,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["high-mounted tail boom", "large cabin"]
+        "distinctiveFeatures": [
+          "high-mounted tail boom",
+          "large cabin"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6783,10 +8660,32 @@
   },
   {
     "key": "SH-3 Sea King",
-    "altNames": ["SH-3", "Sea King"],
-    "tags": ["Utility Helicopter", "Naval", "USA"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "SH-3 Sea King",
+      "SH-3",
+      "Sea King"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Naval",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6858,7 +8757,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["boat-shaped hull", "large cabin"]
+        "distinctiveFeatures": [
+          "boat-shaped hull",
+          "large cabin"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6878,10 +8780,32 @@
   },
   {
     "key": "VH-3 Sea King",
-    "altNames": ["VH-3", "Sea King"],
-    "tags": ["Utility Helicopter", "VIP Transport", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "VH-3 Sea King",
+      "VH-3",
+      "Sea King"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "VIP Transport",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/nz02SsK/159351-united-states-marine-corps-sikorsky-vh-3d-sea-king-Planespotters-Net-1488739-87de74940b-o.jpg",
+      "https://i.ibb.co/QvZ03J5/159356-united-states-marine-corps-sikorsky-vh-3d-sea-king-Planespotters-Net-1542271-359d6381ba-o.jpg",
+      "https://i.ibb.co/WKZDDf4/159357-united-states-marine-corps-sikorsky-vh-3d-sea-king-Planespotters-Net-1013907-7e1a286f3f-o.jpg",
+      "https://i.ibb.co/W0L7M0C/159357-united-states-marine-corps-sikorsky-vh-3d-sea-king-Planespotters-Net-1450963-e0a98842cc-o.jpg",
+      "https://i.ibb.co/CHv1JZf/159350-united-states-marine-corps-sikorsky-vh-3d-sea-king-Planespotters-Net-1542270-87fbf50bbe-o.jpg",
+      "https://i.ibb.co/HV5F9y5/159351-united-states-marine-corps-sikorsky-vh-3d-sea-king-Planespotters-Net-585253-09fe8de894-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/W0L7M0C/159357-united-states-marine-corps-sikorsky-vh-3d-sea-king-Planespotters-Net-1450963-e0a98842cc-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -6953,7 +8877,10 @@
       },
       "fuselage": {
         "shape": "boat-shaped",
-        "distinctiveFeatures": ["VIP interior modifications", "large cabin"]
+        "distinctiveFeatures": [
+          "VIP interior modifications",
+          "large cabin"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -6973,10 +8900,32 @@
   },
   {
     "key": "VH-92 Patriot",
-    "altNames": ["VH-92", "Patiot"],
-    "tags": ["Utility Helicopter", "VIP Transport", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "VH-92 Patriot",
+      "VH-92",
+      "Patiot"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "VIP Transport",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/6XQBsDF/EDM1-Sep-2018-Released.jpg",
+      "https://i.ibb.co/Y7RH4Cv/ezgif-7-6cc916981a.jpg",
+      "https://i.ibb.co/5nGb2Nc/VH-92-Quantico.jpg",
+      "https://i.ibb.co/B2xQtxY/ezgif-2-c253cc1ca5.jpg",
+      "https://i.ibb.co/0c9w45W/ezgif-7-3333e49591.jpg",
+      "https://i.ibb.co/Z6TrC6b/ezgif-7-ae26d589b0.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/Z6TrC6b/ezgif-7-ae26d589b0.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7048,7 +8997,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["sleek fuselage", "VIP transport"]
+        "distinctiveFeatures": [
+          "sleek fuselage",
+          "VIP transport"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -7068,10 +9020,32 @@
   },
   {
     "key": "KA-27 Helix",
-    "altNames": ["KA-27", "Helix"],
-    "tags": ["Utility Helicopter", "Naval", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "KA-27 Helix",
+      "KA-27",
+      "Helix"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Naval",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7143,7 +9117,10 @@
       },
       "fuselage": {
         "shape": "boat-shaped",
-        "distinctiveFeatures": ["coaxial rotor system", "small cabin for equipment or crew"]
+        "distinctiveFeatures": [
+          "coaxial rotor system",
+          "small cabin for equipment or crew"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -7163,10 +9140,32 @@
   },
   {
     "key": "CH-46 Sea Knight",
-    "altNames": ["CH-46", "Sea Knight"],
-    "tags": ["Utility Helicopter", "Transport", "USA"],
-    "hltag": ["Rotor-Wing", "Utility"],
-    "accat": [],
+    "altNames": [
+      "CH-46 Sea Knight",
+      "CH-46",
+      "Sea Knight"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Transport",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7238,7 +9237,10 @@
       },
       "fuselage": {
         "shape": "medium-sized",
-        "distinctiveFeatures": ["twin-rotor design", "rear cargo ramp"]
+        "distinctiveFeatures": [
+          "twin-rotor design",
+          "rear cargo ramp"
+        ]
       },
       "tail": {
         "type": "none",
@@ -7258,10 +9260,33 @@
   },
   {
     "key": "SH-60 Seahawk",
-    "altNames": ["SH-60", "Seahawk"],
-    "tags": ["Utility Helicopter", "Naval", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "SH-60 Seahawk",
+      "SH-60",
+      "Seahawk"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Naval",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7333,7 +9358,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["four-blade rotor", "naval adaptations for shipboard operations"]
+        "distinctiveFeatures": [
+          "four-blade rotor",
+          "naval adaptations for shipboard operations"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -7353,10 +9381,36 @@
   },
   {
     "key": "UH-1 Iroquois (Huey)",
-    "altNames": ["UH-1 Iroquois", "UH-1 Huey", "UH-1", "Iroquois", "Huey"],
-    "tags": ["Utility Helicopter", "Transport", "USA", "Cold War"],
-    "hltag": ["Rotor-Wing", "Utility"],
-    "accat": [],
+    "altNames": [
+      "UH-1 Iroquois (Huey)",
+      "UH-1 Iroquois",
+      "UH-1 Huey",
+      "UH-1",
+      "Iroquois",
+      "Huey"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Transport",
+      "USA",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7428,7 +9482,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["large cabin", "skids for landing"]
+        "distinctiveFeatures": [
+          "large cabin",
+          "skids for landing"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -7448,10 +9505,31 @@
   },
   {
     "key": "BO-105",
-    "altNames": [""],
-    "tags": ["Recon Helicopter", "Light Utility", "Germany"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Recon", "Utility"],
+    "altNames": [
+      "BO-105"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Light Utility",
+      "Germany"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/LQSDFGW/n154eh-era-helicopters-mbb-bo-105-s-Planespotters-Net-448349-24ae164099-o.jpg",
+      "https://i.ibb.co/wNbc26q/n154eh-era-helicopters-mbb-bo-105-s-Planespotters-Net-1620539-67d2450f38-o.jpg",
+      "https://i.ibb.co/pvdTn4B/n154eh-red-bull-north-america-mbb-bo-105-s-Planespotters-Net-1657819-9e4ae27031-o.jpg",
+      "https://i.ibb.co/sR8WkVH/sp-ybo-private-mbb-bo-105-m-vbh-Planespotters-Net-1292420-305d221c30-o.jpg",
+      "https://i.ibb.co/6R0f9Pg/8716-german-army-mbb-bo-105p1m-Planespotters-Net-741125-7aef7a6227-o.jpg",
+      "https://i.ibb.co/s6vpG7M/d-hbwh-air-lloyd-mbb-bo-105-cbs-5-Planespotters-Net-1116629-b48b4d9e2f-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/wNbc26q/n154eh-era-helicopters-mbb-bo-105-s-Planespotters-Net-1620539-67d2450f38-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7523,7 +9601,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["rigid rotor system", "light utility fuselage"]
+        "distinctiveFeatures": [
+          "rigid rotor system",
+          "light utility fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -7543,10 +9624,34 @@
   },
   {
     "key": "MD-500 Defender",
-    "altNames": ["MD-500", "Defender 500", "MD Defender 500 "],
-    "tags": ["Recon Helicopter", "Attack", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Recon", "Attack"],
+    "altNames": [
+      "MD-500 Defender",
+      "MD-500",
+      "Defender 500",
+      "MD Defender 500 "
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Attack",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/72hGWcZ/d-hilv-private-md-helicopters-md-500e-Planespotters-Net-1523756-769907fb7d-o.jpg",
+      "https://i.ibb.co/QKWSTk2/d-hilv-private-md-helicopters-md-500e-Planespotters-Net-424024-70aa582348-o.jpg",
+      "https://i.ibb.co/FVH5RBP/d-hxxx-private-md-helicopters-md-500e-Planespotters-Net-967776-1d133553b3-o.jpg",
+      "https://i.ibb.co/BjcY8zZ/hb-zkd-fuchs-helikopter-md-helicopters-md-500e-369e-Planespotters-Net-586893-dc4ba8c29b-o.jpg",
+      "https://i.ibb.co/6FfXmYH/n911rp-riverside-police-department-md-helicopters-md-500e-369e-Planespotters-Net-1221186-7da42aafbf.jpg",
+      "https://i.ibb.co/z2N16LK/r503-mcdonnell-douglas-md500e-hungarian-police-dept-Planespotters-Net-886579-4842b22ade-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/z2N16LK/r503-mcdonnell-douglas-md500e-hungarian-police-dept-Planespotters-Net-886579-4842b22ade-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon",
+      "Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7618,7 +9723,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["bubble canopy", "light utility fuselage"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "light utility fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -7638,10 +9746,32 @@
   },
   {
     "key": "OH-58 Kiowa",
-    "altNames": ["OH-58", "Kiowa"],
-    "tags": ["Recon Helicopter", "USA", "Cold War"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Recon"],
+    "altNames": [
+      "OH-58 Kiowa",
+      "OH-58",
+      "Kiowa"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "USA",
+      "Cold War"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7713,7 +9843,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["mast-mounted sight", "compact cabin"]
+        "distinctiveFeatures": [
+          "mast-mounted sight",
+          "compact cabin"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -7733,10 +9866,33 @@
   },
   {
     "key": "OH-6A Cayuse",
-    "altNames": ["OH-6A", "Cayuse"],
-    "tags": ["Recon Helicopter", "Light Utility", "USA"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Recon", "Utility"],
+    "altNames": [
+      "OH-6A Cayuse",
+      "OH-6A",
+      "Cayuse"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Light Utility",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7808,7 +9964,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["egg-shaped fuselage", "bubble canopy"]
+        "distinctiveFeatures": [
+          "egg-shaped fuselage",
+          "bubble canopy"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -7828,10 +9987,29 @@
   },
   {
     "key": "Z-9 Harbin",
-    "altNames": [""],
-    "tags": ["Recon Helicopter", "China"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Recon"],
+    "altNames": [
+      "Z-9 Harbin"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "China"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7903,7 +10081,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["fenestron tail rotor", "medium-sized fuselage"]
+        "distinctiveFeatures": [
+          "fenestron tail rotor",
+          "medium-sized fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -7923,10 +10104,33 @@
   },
   {
     "key": "AS-350 Squirrel",
-    "altNames": ["AS-350", "Squirrel"],
-    "tags": ["Recon Helicopter", "Light Utility", "France"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Recon", "Utility"],
+    "altNames": [
+      "AS-350 Squirrel",
+      "AS-350",
+      "Squirrel"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Light Utility",
+      "France"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/0jh1vQ9/d-haup-meravo-helicopters-aerospatiale-as-350ba-ecureuil-Planespotters-Net-1637827-6baed9be9b-o.jpg",
+      "https://i.ibb.co/y0qdZY3/d-hmmw-spluftbild-dattenberg-aerospatiale-as-350-b-ecureuil-Planespotters-Net-1311057-db03d6adcc-o.jpg",
+      "https://i.ibb.co/gRvs6Yt/hb-zib-swiss-helicopter-ag-ecureuil-as350-Planespotters-Net-583945-b1cb3ec552-o.jpg",
+      "https://i.ibb.co/x7zrtWN/hb-zsv-heli-bernina-ag-eurocopter-as-350b-3-ecureuil-Planespotters-Net-1561591-7ffbe5e66a-o.jpg",
+      "https://i.ibb.co/XzTGgyZ/101-hungarian-air-force-aerospatiale-as-350-b-2-cureuil-Planespotters-Net-1234780-97cdee94a7-o.jpg",
+      "https://i.ibb.co/9VtT1G2/102-hungarian-air-force-aerospatiale-as350-b-ecureuil-Planespotters-Net-987174-89d6313e35-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/gRvs6Yt/hb-zib-swiss-helicopter-ag-ecureuil-as350-Planespotters-Net-583945-b1cb3ec552-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -7998,7 +10202,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["bubble canopy", "light utility fuselage"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "light utility fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8018,10 +10225,31 @@
   },
   {
     "key": "AW-109 Power",
-    "altNames": [""],
-    "tags": ["Recon Helicopter", "Utility", "Italy"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Recon", "Utility"],
+    "altNames": [
+      "AW-109 Power"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/db9sLD9/hb-zrr-rega-agustawestland-aw109sp-davinci-Planespotters-Net-178770-358ba3fbf4-o.jpg",
+      "https://i.ibb.co/sCtXLDH/hb-zrr-rega-agustawestland-aw109sp-davinci-Planespotters-Net-1649739-9ae04b7575-o.jpg",
+      "https://i.ibb.co/TT9nd3p/i-pntf-elitaliana-agustawestland-aw109sp-grand-new-Planespotters-Net-844692-82cde0e2b4-o.jpg",
+      "https://i.ibb.co/SK4t4J7/ti-bkx-private-agusta-westland-aw-109-trekker-Planespotters-Net-1655262-2544f277ce-o.jpg",
+      "https://i.ibb.co/BLsq3Qd/g-thdr-thunder-aviation-ltd-agustawestland-aw109sp-grand-new-Planespotters-Net-1668672-09ae7c0c40-o.jpg",
+      "https://i.ibb.co/RcRM8gw/gz100-royal-air-force-agustawestland-aw109sp-grand-new-Planespotters-Net-897313-d13cb6c78e-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/sCtXLDH/hb-zrr-rega-agustawestland-aw109sp-davinci-Planespotters-Net-1649739-9ae04b7575-o.jpg",
+    "tags": [
+      "Recon Helicopter",
+      "Utility",
+      "Italy"
+    ],
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8093,7 +10321,10 @@
       },
       "fuselage": {
         "shape": "sleek",
-        "distinctiveFeatures": ["streamlined fuselage", "retractable landing gear"]
+        "distinctiveFeatures": [
+          "streamlined fuselage",
+          "retractable landing gear"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8113,10 +10344,31 @@
   },
   {
     "key": "Bell 206",
-    "altNames": [""],
-    "tags": ["Recon Helicopter", "Light Utility", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Recon", "Utility"],
+    "altNames": [
+      "Bell 206"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Light Utility",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/RzZYFz5/d-hkgb-agrarflug-helilift-bell-206b-3-jetranger-iii-Planespotters-Net-1540814-1691ed1b1e-o.jpg",
+      "https://i.ibb.co/BPsB2hv/f-gxxj-air-tourraine-bell-206l-longranger-Planespotters-Net-1658090-13110ae848-o.jpg",
+      "https://i.ibb.co/rythXhN/n2nj-new-jersey-state-police-bell-206l-3-longranger-iii-Planespotters-Net-1624951-8312a3fa82-o.jpg",
+      "https://i.ibb.co/bFHyyRb/n8qv-private-bell-206b-jetranger-ii-Planespotters-Net-1637429-3def3b6087-o.jpg",
+      "https://i.ibb.co/G79R2j3/9m-awc-sabah-air-aviation-bell-206b-3-jetranger-iii-Planespotters-Net-1618253-b6e936ffc7-o.jpg",
+      "https://i.ibb.co/h933mFM/d-hhkw-private-bell-206b-3-jetranger-iii-Planespotters-Net-1533129-7782cdb37e-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/bFHyyRb/n8qv-private-bell-206b-jetranger-ii-Planespotters-Net-1637429-3def3b6087-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8188,7 +10440,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["bubble canopy", "light utility fuselage"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "light utility fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8208,10 +10463,30 @@
   },
   {
     "key": "Bell 412",
-    "altNames": [""],
-    "tags": ["Utility Helicopter", "Transport", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "Bell 412"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Transport",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/3FCgT9B/ja21ap-aichi-police-bell-412ep-Planespotters-Net-1574876-edce8976ce-o.jpg",
+      "https://i.ibb.co/jVNHW69/knp957-korea-national-police-air-corps-bell-412ep-Planespotters-Net-1562383-a3711100a3-o.jpg",
+      "https://i.ibb.co/589dCQd/oe-xht-private-bell-412-Planespotters-Net-1596443-3ab9518779-o.jpg",
+      "https://i.ibb.co/fCLSMkk/zj705-royal-air-force-bell-412ep-Planespotters-Net-1558849-8649d33c5d-o.jpg",
+      "https://i.ibb.co/KGhwz4T/146425-canadian-armed-forces-bell-ch-146-griffon-Planespotters-Net-1608553-d726f4271b-o.jpg",
+      "https://i.ibb.co/BtM7DyX/ec-mkc-pegasus-aviacin-bell-412ep-Planespotters-Net-1653542-a4ebb6b8bb-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/KGhwz4T/146425-canadian-armed-forces-bell-ch-146-griffon-Planespotters-Net-1608553-d726f4271b-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8283,7 +10558,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["four-blade rotor", "medium utility cabin"]
+        "distinctiveFeatures": [
+          "four-blade rotor",
+          "medium utility cabin"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8303,10 +10581,31 @@
   },
   {
     "key": "EC-120",
-    "altNames": [""],
-    "tags": ["Recon Helicopter", "Light Utility", "France"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Recon", "Utility"],
+    "altNames": [
+      "EC-120"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Light Utility",
+      "France"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/5rdbmf7/hb-zgj-air-evolution-eurocopter-ec120b-colibri-Planespotters-Net-1549324-a96351824a-o.jpg",
+      "https://i.ibb.co/dDtmHmD/oo-ddc-private-eurocopter-ec120b-colibri-Planespotters-Net-1639069-da5f532453-o.jpg",
+      "https://i.ibb.co/7rynG8T/pp-mjm-private-eurocopter-ec120b-colibri-Planespotters-Net-1660305-c8d8c41e5e-o.jpg",
+      "https://i.ibb.co/g7L767H/pr-isi-private-eurocopter-ec120b-colibri-Planespotters-Net-1664687-967a2cd725-o.jpg",
+      "https://i.ibb.co/Xk030c7/g-wzrd-private-eurocopter-ec120-colibri-Planespotters-Net-791630-34e378908c-o.jpg",
+      "https://i.ibb.co/hKWwZmS/hb-zbd-helitrans-eurocopter-ec120b-colibri-Planespotters-Net-1657491-6792c38ef6-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/Xk030c7/g-wzrd-private-eurocopter-ec120-colibri-Planespotters-Net-791630-34e378908c-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8378,7 +10677,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["bubble canopy", "fenestron tail rotor"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "fenestron tail rotor"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8398,10 +10700,31 @@
   },
   {
     "key": "EC-135",
-    "altNames": [""],
-    "tags": ["Utility Helicopter", "Transport", "France", "Germany"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Utility"],
+    "altNames": [
+      "EC-135"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Transport",
+      "France",
+      "Germany"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/pL7kZz2/oe-xvp-christophorus-flugrettungsverein-amtc-eurocopter-ec135-t3h-Planespotters-Net-1433766-18db2a2f.jpg",
+      "https://i.ibb.co/y53KwhT/om-atw-air-transport-europe-eurocopter-ec135-t2-Planespotters-Net-1637797-9ff8627eda-o.jpg",
+      "https://i.ibb.co/4Sy3bVx/d-htwo-polizei-hamburg-eurocopter-ec135-p2-Planespotters-Net-1599900-b0f93b3cc1-o.jpg",
+      "https://i.ibb.co/wcjkN63/d-hzsc-bundesministerium-des-innern-bmi-eurocopter-ec135-t2-ec135-t2i-Planespotters-Net-1590931-d324.jpg",
+      "https://i.ibb.co/DLyh1hr/hb-zrk-air-glaciers-eurocopter-ec135-t1-Planespotters-Net-1637715-7d429779d6-o.jpg",
+      "https://i.ibb.co/FsnKnB3/oe-bxr-flugpolizei-air-police-eurocopter-ec135-p3-Planespotters-Net-1633235-7c298b2fe4-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/4Sy3bVx/d-htwo-polizei-hamburg-eurocopter-ec135-p2-Planespotters-Net-1599900-b0f93b3cc1-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8496,10 +10819,33 @@
   },
   {
     "key": "HH-65 Dolphin",
-    "altNames": ["HH-65", "Dolphin"],
-    "tags": ["Utility Helicopter", "Search and Rescue", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Utility", "SAR"],
+    "altNames": [
+      "HH-65 Dolphin",
+      "HH-65",
+      "Dolphin"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Search and Rescue",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/VByvRxy/6594-united-states-coast-guard-aerospatiale-mh-65-dolphin-Planespotters-Net-1291249-6b86640f92-o.jpg",
+      "https://i.ibb.co/rtz7fP3/6607-united-states-coast-guard-arospatiale-mh-65e-dolphin-Planespotters-Net-1576893-40a5db775c-o.jpg",
+      "https://i.ibb.co/L8BN4r9/6515-united-states-coast-guard-aerospatiale-hh-65c-dolphin-Planespotters-Net-673899-2f914ae55f-o.jpg",
+      "https://i.ibb.co/vVf5MB5/6543-united-states-coast-guard-mh-65d-dolphin-Planespotters-Net-1425482-c93b74fa29-o.jpg",
+      "https://i.ibb.co/F87JFrN/6568-united-states-coast-guard-arospatiale-mh-65d-dolphin-Planespotters-Net-1115931-53d76804fd-o.jpg",
+      "https://i.ibb.co/26kyMsC/6573-united-states-coast-guard-eurocopter-mh-65d-dolphin-Planespotters-Net-1486431-2d8f063be5-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/vVf5MB5/6543-united-states-coast-guard-mh-65d-dolphin-Planespotters-Net-1425482-c93b74fa29-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility",
+      "SAR"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8571,7 +10917,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["fenestron tail rotor", "sleek design"]
+        "distinctiveFeatures": [
+          "fenestron tail rotor",
+          "sleek design"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8591,10 +10940,34 @@
   },
   {
     "key": "Robinson R-44 Raven",
-    "altNames": ["Robinson R-44 Raven", "R-44", "Raven", "Raven II"],
-    "tags": ["Recon Helicopter", "Utility", "Civil"],
-    "hltag": ["NCR"],
-    "accat": ["Rotor-Wing", "Utility", "Recon"],
+    "altNames": [
+      "Robinson R-44 Raven",
+      "R-44",
+      "Raven",
+      "Raven II"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Utility",
+      "Civil"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/m6cj2sg/sp-hsa-heli-solution-robinson-helicopter-r44-raven-ii-Planespotters-Net-1625251-cd1ccc933f-o.jpg",
+      "https://i.ibb.co/ChyVkzP/oo-cat-private-robinson-helicopter-r44-clipper-ii-Planespotters-Net-1633625-c77d26378f-o.jpg",
+      "https://i.ibb.co/dLz78Gh/b-7279-private-robinson-helicopter-r44-raven-Planespotters-Net-1632975-860eab7b5f-o.jpg",
+      "https://i.ibb.co/kX0jmGY/f-gvyd-private-robinson-helicopter-r44-raven-ii-Planespotters-Net-1656519-939b87b7f0-o.jpg",
+      "https://i.ibb.co/qRS8MTw/g-ddad-private-robinson-helicopter-r44-Planespotters-Net-1668660-fac4454085-o.jpg",
+      "https://i.ibb.co/WPhXcx9/g-herz-private-robinson-helicopter-r44-astro-Planespotters-Net-1668661-f21ae5e875-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/qRS8MTw/g-ddad-private-robinson-helicopter-r44-Planespotters-Net-1668660-fac4454085-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8666,7 +11039,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["bubble canopy", "light utility fuselage"]
+        "distinctiveFeatures": [
+          "bubble canopy",
+          "light utility fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8686,10 +11062,33 @@
   },
   {
     "key": "AH-6 Little Bird",
-    "altNames": ["AH-6", "Little Bird"],
-    "tags": ["Recon Helicopter", "Light Attack", "USA"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Recon", "Attack"],
+    "altNames": [
+      "AH-6 Little Bird",
+      "AH-6",
+      "Little Bird"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Light Attack",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Recon",
+      "Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8761,7 +11160,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["highly maneuverable", "small size"]
+        "distinctiveFeatures": [
+          "highly maneuverable",
+          "small size"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8781,10 +11183,33 @@
   },
   {
     "key": "MI-2 Hoplite",
-    "altNames": ["MI-2", "Hoplite"],
-    "tags": ["Recon Helicopter", "Utility", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Utility", "Recon"],
+    "altNames": [
+      "MI-2 Hoplite",
+      "MI-2",
+      "Hoplite"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Utility",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8856,7 +11281,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["light utility design", "two-blade rotor system"]
+        "distinctiveFeatures": [
+          "light utility design",
+          "two-blade rotor system"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8876,10 +11304,32 @@
   },
   {
     "key": "Gazelle",
-    "altNames": [""],
-    "tags": ["Recon Helicopter", "Light Utility", "France", "UK"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Utility", "Recon"],
+    "altNames": [
+      "Gazelle"
+    ],
+    "tags": [
+      "Recon Helicopter",
+      "Light Utility",
+      "France",
+      "UK"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -8951,7 +11401,10 @@
       },
       "fuselage": {
         "shape": "slim",
-        "distinctiveFeatures": ["fenestron tail rotor", "light utility design"]
+        "distinctiveFeatures": [
+          "fenestron tail rotor",
+          "light utility design"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -8971,10 +11424,31 @@
   },
   {
     "key": "Bell 407",
-    "altNames": [""],
-    "tags": ["Utility Helicopter", "Recon", "USA"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing", "Utility", "Recon"],
+    "altNames": [
+      "Bell 407"
+    ],
+    "tags": [
+      "Utility Helicopter",
+      "Recon",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing",
+      "Utility",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9046,7 +11520,10 @@
       },
       "fuselage": {
         "shape": "spacious",
-        "distinctiveFeatures": ["four-blade main rotor", "advanced avionics"]
+        "distinctiveFeatures": [
+          "four-blade main rotor",
+          "advanced avionics"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -9066,10 +11543,33 @@
   },
   {
     "key": "MQ-1 Predator",
-    "altNames": ["MQ-1", "Predator"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "USA"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing UAV", "Surveillance"],
+    "altNames": [
+      "MQ-1 Predator",
+      "MQ-1",
+      "Predator"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9141,7 +11641,10 @@
       },
       "fuselage": {
         "shape": "long and slender",
-        "distinctiveFeatures": ["bulbous nose", "sensor housing"]
+        "distinctiveFeatures": [
+          "bulbous nose",
+          "sensor housing"
+        ]
       },
       "tail": {
         "type": "V-tail",
@@ -9161,10 +11664,32 @@
   },
   {
     "key": "MQ-5B Hunter",
-    "altNames": ["MQ-5B", "Hunter"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "USA"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing UAV", "Surveillance"],
+    "altNames": [
+      "MQ-5B Hunter",
+      "MQ-5B",
+      "Hunter"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9236,7 +11761,9 @@
       },
       "fuselage": {
         "shape": "central fuselage pod",
-        "distinctiveFeatures": ["twin-boom design"]
+        "distinctiveFeatures": [
+          "twin-boom design"
+        ]
       },
       "tail": {
         "type": "V-tail",
@@ -9256,10 +11783,34 @@
   },
   {
     "key": "MQ-9 Reaper",
-    "altNames": ["MQ-9", "Reaper"],
-    "tags": ["Unmanned Aircraft", "Surveillance", "Attack", "USA"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing UAV", "Attack", "Surveillance"],
+    "altNames": [
+      "MQ-9 Reaper",
+      "MQ-9",
+      "Reaper"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Surveillance",
+      "Attack",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Attack",
+      "Surveillance"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9331,7 +11882,10 @@
       },
       "fuselage": {
         "shape": "long and slender",
-        "distinctiveFeatures": ["sensor housing", "external hardpoints"]
+        "distinctiveFeatures": [
+          "sensor housing",
+          "external hardpoints"
+        ]
       },
       "tail": {
         "type": "V-tail",
@@ -9351,10 +11905,35 @@
   },
   {
     "key": "MQ-8 Fire Scout",
-    "altNames": ["MQ-8", "Fire Scout"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "Rotor-Wing", "USA"],
-    "hltag": [""],
-    "accat": ["Rotor-Wing UAV", "Surveillance", "Recon"],
+    "altNames": [
+      "MQ-8 Fire Scout",
+      "MQ-8",
+      "Fire Scout"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "Rotor-Wing",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Rotor-Wing UAV",
+      "Surveillance",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9426,7 +12005,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["unmanned helicopter", "sensors on nose"]
+        "distinctiveFeatures": [
+          "unmanned helicopter",
+          "sensors on nose"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -9446,10 +12028,33 @@
   },
   {
     "key": "RQ-2 Pioneer",
-    "altNames": ["RQ-2", "Pioneer"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "USA"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing UAV", "Surveillance"],
+    "altNames": [
+      "RQ-2 Pioneer",
+      "RQ-2",
+      "Pioneer"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9521,7 +12126,10 @@
       },
       "fuselage": {
         "shape": "twin-boom",
-        "distinctiveFeatures": ["central pod", "long nose housing sensors"]
+        "distinctiveFeatures": [
+          "central pod",
+          "long nose housing sensors"
+        ]
       },
       "tail": {
         "type": "twin-boom",
@@ -9541,10 +12149,34 @@
   },
   {
     "key": "RQ-4 Global Hawk",
-    "altNames": ["RQ-4", "Global Hawk"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing UAV", "Surveillance"],
+    "altNames": [
+      "RQ-4 Global Hawk",
+      "RQ-4",
+      "Global Hawk"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9616,7 +12248,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["long fuselage", "bulbous nose"]
+        "distinctiveFeatures": [
+          "long fuselage",
+          "bulbous nose"
+        ]
       },
       "tail": {
         "type": "V-tail",
@@ -9636,10 +12271,34 @@
   },
   {
     "key": "RQ-7 Shadow",
-    "altNames": ["RQ-7", "Shadow"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing UAV", "Surveillance"],
+    "altNames": [
+      "RQ-7 Shadow",
+      "RQ-7",
+      "Shadow"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9711,7 +12370,10 @@
       },
       "fuselage": {
         "shape": "twin-boom",
-        "distinctiveFeatures": ["central pod", "inverted V-tail"]
+        "distinctiveFeatures": [
+          "central pod",
+          "inverted V-tail"
+        ]
       },
       "tail": {
         "type": "inverted V-tail",
@@ -9731,10 +12393,35 @@
   },
   {
     "key": "RQ-170 Sentinel",
-    "altNames": ["RQ-170", "Sentinel"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Stealth", "Surveillance", "USA"],
-    "hltag": [""],
-    "accat": ["Stealth UAV", "Surveillance", "Recon"],
+    "altNames": [
+      "RQ-170 Sentinel",
+      "RQ-170",
+      "Sentinel"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Stealth",
+      "Surveillance",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Stealth UAV",
+      "Surveillance",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9806,7 +12493,10 @@
       },
       "fuselage": {
         "shape": "wing",
-        "distinctiveFeatures": ["stealth optimized", "no tail"]
+        "distinctiveFeatures": [
+          "stealth optimized",
+          "no tail"
+        ]
       },
       "tail": {
         "type": "none",
@@ -9826,10 +12516,33 @@
   },
   {
     "key": "RQ-11B Raven",
-    "altNames": ["RQ-11B", "Raven"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing UAV", "Surveillance"],
+    "altNames": [
+      "RQ-11B",
+      "Raven"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9901,7 +12614,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["hand-launched capability", "lightweight design"]
+        "distinctiveFeatures": [
+          "hand-launched capability",
+          "lightweight design"
+        ]
       },
       "tail": {
         "type": "V-tail",
@@ -9920,10 +12636,31 @@
   },
   {
     "key": "ScanEagle",
-    "altNames": [""],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "USA"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing UAV", "Surveillance"],
+    "altNames": [
+      "ScanEagle"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -9995,7 +12732,10 @@
       },
       "fuselage": {
         "shape": "slim",
-        "distinctiveFeatures": ["long endurance", "lightweight structure"]
+        "distinctiveFeatures": [
+          "long endurance",
+          "lightweight structure"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -10014,10 +12754,34 @@
   },
   {
     "key": "Shmel-1 Yak-061",
-    "altNames": ["Shmel-1", "Yak-061"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing UAV", "Surveillance", "Recon"],
+    "altNames": [
+      "Shmel-1 Yak-061",
+      "Shmel-1",
+      "Yak-061"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10089,7 +12853,10 @@
       },
       "fuselage": {
         "shape": "twin-boom",
-        "distinctiveFeatures": ["central pod for sensors", "twin-boom design"]
+        "distinctiveFeatures": [
+          "central pod for sensors",
+          "twin-boom design"
+        ]
       },
       "tail": {
         "type": "twin-boom",
@@ -10108,10 +12875,34 @@
   },
   {
     "key": "Mirach 100 Meteor",
-    "altNames": ["Mirach 100", "Meteor"],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "Italy"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing UAV", "Surveillance", "Recon"],
+    "altNames": [
+      "Mirach 100 Meteor",
+      "Mirach 100",
+      "Meteor"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "Italy"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10183,7 +12974,10 @@
       },
       "fuselage": {
         "shape": "slim",
-        "distinctiveFeatures": ["target drone", "pointed nose"]
+        "distinctiveFeatures": [
+          "target drone",
+          "pointed nose"
+        ]
       },
       "tail": {
         "type": "V-tail",
@@ -10202,10 +12996,33 @@
   },
   {
     "key": "Orlan-10",
-    "altNames": [],
-    "tags": ["Unmanned Aircraft", "Reconnaissance", "Surveillance", "Russia"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing UAV", "Surveillance", "Recon"],
+    "altNames": [
+      "Orlan-10"
+    ],
+    "tags": [
+      "Unmanned Aircraft",
+      "Reconnaissance",
+      "Surveillance",
+      "Russia"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing UAV",
+      "Surveillance",
+      "Recon"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10277,7 +13094,10 @@
       },
       "fuselage": {
         "shape": "lightweight",
-        "distinctiveFeatures": ["high-mounted wing", "pusher propeller"]
+        "distinctiveFeatures": [
+          "high-mounted wing",
+          "pusher propeller"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -10296,10 +13116,29 @@
   },
   {
     "key": "Airbus A300",
-    "altNames": ["A300"],
+    "altNames": [
+      "Airbus A300",
+      "A300"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/RhpsfJS/ep-ibc-iran-air-airbus-a300b4-605r-Planespotters-Net-1626275-bbaffbde84-o.jpg",
+      "https://i.ibb.co/hXTwfD4/n129up-united-parcel-service-ups-airbus-a300f4-622r-Planespotters-Net-1621180-bb3829f500-o.jpg",
+      "https://i.ibb.co/WvZGSz7/n650fe-fedex-express-airbus-a300f4-605r-Planespotters-Net-317095-51094b48e8-o.jpg",
+      "https://i.ibb.co/XtbSBxP/su-bmz-tristar-air-airbus-a300b4-203f-Planespotters-Net-429036-53c66da3de-o.jpg",
+      "https://i.ibb.co/QFtx53s/d-aeaq-dhl-aviation-airbus-a300b4-622rf-Planespotters-Net-1636576-07b8baf1fb-o.jpg",
+      "https://i.ibb.co/z2jQ7HN/d-azml-dhl-aviation-airbus-a300b4-622rf-Planespotters-Net-1620245-47c0e7e267-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/QFtx53s/d-aeaq-dhl-aviation-airbus-a300b4-622rf-Planespotters-Net-1636576-07b8baf1fb-o.jpg",
     "tags": [],
-    "hltag": ["NCR"],
-    "accat": ["Airliner", "Passenger", "Cargo", "Europe"],
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Airliner",
+      "Passenger",
+      "Cargo",
+      "Europe"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10371,7 +13210,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["wide fuselage", "two-deck layout"]
+        "distinctiveFeatures": [
+          "wide fuselage",
+          "two-deck layout"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -10390,10 +13232,29 @@
   },
   {
     "key": "Airbus A320",
-    "altNames": ["A320"],
+    "altNames": [
+      "Airbus A320",
+      "A320"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/L69GDFn/c-gojq-air-transat-airbus-a321-271nx-Planespotters-Net-1664304-a31513ec01-o.jpg",
+      "https://i.ibb.co/LZ2f7SY/d-aiux-discover-airlines-airbus-a320-214wl-Planespotters-Net-1658532-c72396bde8-o.jpg",
+      "https://i.ibb.co/cTB0GhW/ec-nor-volotea-airlines-airbus-a320-216-Planespotters-Net-1659883-208a0a5274-o.jpg",
+      "https://i.ibb.co/XDh30jM/n612jb-jetblue-airbus-a320-232-Planespotters-Net-1669583-eda2439fa8-o.jpg",
+      "https://i.ibb.co/sFVxPr1/b-30fv-loong-air-airbus-a320-251n-Planespotters-Net-1616624-3b11bbed1e-o.jpg",
+      "https://i.ibb.co/Rvgnqjy/b-lpt-hong-kong-airlines-airbus-a320-232-Planespotters-Net-1648390-d0c4f0b4c2-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/LZ2f7SY/d-aiux-discover-airlines-airbus-a320-214wl-Planespotters-Net-1658532-c72396bde8-o.jpg",
     "tags": [],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Transport", "Airliner"],
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Airliner"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10465,7 +13326,9 @@
       },
       "fuselage": {
         "shape": "narrow-body",
-        "distinctiveFeatures": ["fly-by-wire control system"]
+        "distinctiveFeatures": [
+          "fly-by-wire control system"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -10484,10 +13347,32 @@
   },
   {
     "key": "Airbus A330",
-    "altNames": ["A330"],
-    "tags": ["Airliner", "Passenger", "Europe"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport", "Airliner"],
+    "altNames": [
+      "Airbus A330",
+      "A330"
+    ],
+    "tags": [
+      "Airliner",
+      "Passenger",
+      "Europe"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/cJ9nG0V/b-6115-air-china-airbus-a330-243-Planespotters-Net-1657608-c8a45d3083-o.jpg",
+      "https://i.ibb.co/bBcBVxG/c-ghkw-air-canada-airbus-a330-343-Planespotters-Net-1664301-f0897b0531-o.jpg",
+      "https://i.ibb.co/RNDPnKK/d-aikc-discover-airlines-airbus-a330-343-Planespotters-Net-1664299-84d5b2194a-o.jpg",
+      "https://i.ibb.co/KjXQHhh/d-anre-condor-airbus-a330-941-Planespotters-Net-1651112-2d0f9230b4-o.jpg",
+      "https://i.ibb.co/g9Pk8g5/b-5976-china-eastern-airlines-airbus-a330-343-Planespotters-Net-1403284-2cada47656-o.jpg",
+      "https://i.ibb.co/Zz8m5mD/b-5977-air-china-airbus-a330-343-Planespotters-Net-1292804-274c99b58f-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/RNDPnKK/d-aikc-discover-airlines-airbus-a330-343-Planespotters-Net-1664299-84d5b2194a-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Airliner"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10559,7 +13444,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["long-range", "spacious cabin"]
+        "distinctiveFeatures": [
+          "long-range",
+          "spacious cabin"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -10578,10 +13466,33 @@
   },
   {
     "key": "Airbus A340",
-    "altNames": ["A340"],
-    "tags": ["Airliner", "Passenger", "Europe"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Transport", "Airliner"],
+    "altNames": [
+      "Airbus A340",
+      "A340"
+    ],
+    "tags": [
+      "Airliner",
+      "Passenger",
+      "Europe"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/MkG6dFc/d-ausz-universal-sky-carrier-usc-airbus-a340-642-Planespotters-Net-1664303-eb61b3de6c-o.jpg",
+      "https://i.ibb.co/2MLBCpf/ep-mmr-mahan-air-airbus-a340-642-Planespotters-Net-1643568-cab4d24aa8-o.jpg",
+      "https://i.ibb.co/nbJShMv/lv-csd-aerolineas-argentinas-airbus-a340-313-Planespotters-Net-1614529-7b82fafb19-o.jpg",
+      "https://i.ibb.co/30LXFHn/yr-lrd-legend-airlines-airbus-a340-313-Planespotters-Net-1640279-e8afc64cab-o.jpg",
+      "https://i.ibb.co/FbrD0zT/9h-jai-spicejet-airbus-a340-313-Planespotters-Net-1524675-c9b9941ffb-o.jpg",
+      "https://i.ibb.co/h2yqmQC/d-aihw-lufthansa-airbus-a340-642-Planespotters-Net-1659884-ebf987875b-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/FbrD0zT/9h-jai-spicejet-airbus-a340-313-Planespotters-Net-1524675-c9b9941ffb-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Airliner"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10653,7 +13564,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["four engines", "high aspect ratio wing"]
+        "distinctiveFeatures": [
+          "four engines",
+          "high aspect ratio wing"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -10672,10 +13586,33 @@
   },
   {
     "key": "Boeing 737",
-    "altNames": ["B737"],
-    "tags": ["Airliner", "Passenger", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Transport", "Airliner"],
+    "altNames": [
+      "Boeing 737",
+      "B737"
+    ],
+    "tags": [
+      "Airliner",
+      "Passenger",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/VqNHBMY/ei-ifz-ryanair-boeing-737-8200-max-Planespotters-Net-1669586-4e2ce4ed30-o.jpg",
+      "https://i.ibb.co/rsZ1M7q/n285xa-iaero-airways-boeing-737-4q8-Planespotters-Net-1543245-cccbe5f503-o.jpg",
+      "https://i.ibb.co/nkrtZXr/n786sw-southwest-airlines-boeing-737-7h4wl-Planespotters-Net-1613711-e4145d44dc-o.jpg",
+      "https://i.ibb.co/gP89SPt/pk-rus-raindo-united-services-boeing-737-86nbcfwl-Planespotters-Net-1509972-f416393693-o.jpg",
+      "https://i.ibb.co/PmYDrr4/9m-mva-malaysia-airlines-boeing-737-8-max-Planespotters-Net-1510436-b97903814d-o.jpg",
+      "https://i.ibb.co/df6RdxV/0112-polish-government-boeing-737-8tvwl-bbj2-Planespotters-Net-1352220-070a4d1bdb-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/nkrtZXr/n786sw-southwest-airlines-boeing-737-7h4wl-Planespotters-Net-1613711-e4145d44dc-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Airliner"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10747,7 +13684,10 @@
       },
       "fuselage": {
         "shape": "narrow-body",
-        "distinctiveFeatures": ["reliable airliner", "wide use in commercial aviation"]
+        "distinctiveFeatures": [
+          "reliable airliner",
+          "wide use in commercial aviation"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -10766,10 +13706,35 @@
   },
   {
     "key": "Boeing 747",
-    "altNames": ["B747", "Airforce One"],
-    "tags": ["Airliner", "Passenger", "Cargo", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Transport", "Airliner"],
+    "altNames": [
+      "Boeing 747",
+      "B747",
+      "Airforce One"
+    ],
+    "tags": [
+      "Airliner",
+      "Passenger",
+      "Cargo",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/m0ZRCFt/92-9000-united-states-air-force-boeing-vc-25a-747-2g4b-Planespotters-Net-852592-d8a414dbfd-o.jpg",
+      "https://i.ibb.co/RyTXFwZ/92-9000-united-states-air-force-boeing-vc-25a-747-2g4b-Planespotters-Net-961176-32e700b967-o.jpg",
+      "https://i.ibb.co/KGYdjvF/d-abtl-lufthansa-boeing-747-430-Planespotters-Net-1659699-297ea25dc5-o.jpg",
+      "https://i.ibb.co/7X5vt8w/d-abyp-lufthansa-boeing-747-830-Planespotters-Net-1427611-e13a8580a3-o.jpg",
+      "https://i.ibb.co/0JpTLrF/82-8000-united-states-air-force-boeing-vc-25a-747-2g4b-Planespotters-Net-1188881-7d67317e10-o.jpg",
+      "https://i.ibb.co/BGrDS5v/92-9000-united-states-air-force-boeing-vc-25a-747-2g4b-Planespotters-Net-459645-13e76c4833-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/0JpTLrF/82-8000-united-states-air-force-boeing-vc-25a-747-2g4b-Planespotters-Net-1188881-7d67317e10-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Airliner"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10841,7 +13806,10 @@
       },
       "fuselage": {
         "shape": "humpbacked",
-        "distinctiveFeatures": ["double-deck", "four-engine design"]
+        "distinctiveFeatures": [
+          "double-deck",
+          "four-engine design"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -10860,10 +13828,32 @@
   },
   {
     "key": "Boeing 757",
-    "altNames": ["B757"],
-    "tags": ["Airliner", "Passenger", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport", "Airliner"],
+    "altNames": [
+      "Boeing 757",
+      "B757"
+    ],
+    "tags": [
+      "Airliner",
+      "Passenger",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/xMt9JMF/d-abom-condor-boeing-757-330wl-Planespotters-Net-1651111-4d2de8616c-o.jpg",
+      "https://i.ibb.co/WsSw620/n405up-united-parcel-service-ups-boeing-757-24apf-Planespotters-Net-1645009-1f526f5a01-o.jpg",
+      "https://i.ibb.co/hDW0YHQ/n475up-united-parcel-service-ups-boeing-757-24apf-Planespotters-Net-1632677-c39ac1e618-o.jpg",
+      "https://i.ibb.co/zHCQhWk/n19130-united-airlines-boeing-757-224wl-Planespotters-Net-1668722-179f329658-o.jpg",
+      "https://i.ibb.co/rwcqb0n/19-0018-united-states-air-force-boeing-c-32a-757-2q8wl-Planespotters-Net-1669646-3f785da7ab-o.jpg",
+      "https://i.ibb.co/Xjk3CLt/d-aboj-condor-boeing-757-330wl-Planespotters-Net-1651110-c921314c70-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/WsSw620/n405up-united-parcel-service-ups-boeing-757-24apf-Planespotters-Net-1645009-1f526f5a01-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Airliner"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -10935,7 +13925,10 @@
       },
       "fuselage": {
         "shape": "narrow-body",
-        "distinctiveFeatures": ["high-aspect-ratio wings", "winglets for efficiency"]
+        "distinctiveFeatures": [
+          "high-aspect-ratio wings",
+          "winglets for efficiency"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -10954,10 +13947,32 @@
   },
   {
     "key": "Boeing 767",
-    "altNames": ["B767"],
-    "tags": ["Airliner", "Passenger", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport", "Airliner"],
+    "altNames": [
+      "Boeing 767",
+      "B767"
+    ],
+    "tags": [
+      "Airliner",
+      "Passenger",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/bbp12Lf/n307up-united-parcel-service-ups-boeing-767-34afwl-Planespotters-Net-1594758-9ea52a5544-o.jpg",
+      "https://i.ibb.co/L8qwvWG/n381up-united-parcel-service-ups-boeing-767-300f-Planespotters-Net-1612379-9f5dd1c9ea-o.jpg",
+      "https://i.ibb.co/6Xyc03p/n387up-united-parcel-service-ups-boeing-767-300f-Planespotters-Net-1652787-25277a7cbe-o.jpg",
+      "https://i.ibb.co/0h4695x/uk67014-fly-khiva-boeing-767-304erbcfwl-Planespotters-Net-1656104-5fdcde8bc0-o.jpg",
+      "https://i.ibb.co/y4CFhCK/4l-gtr-airzena-georgian-airways-boeing-767-3q8er-Planespotters-Net-1662739-504a516dc3-o.jpg",
+      "https://i.ibb.co/7jtB0gv/cc-cxe-latam-cargo-chile-boeing-767-316erbcfwl-Planespotters-Net-1664306-4fd2cbacd6-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/L8qwvWG/n381up-united-parcel-service-ups-boeing-767-300f-Planespotters-Net-1612379-9f5dd1c9ea-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Airliner"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11029,7 +14044,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["two-deck layout", "twin-engine design"]
+        "distinctiveFeatures": [
+          "two-deck layout",
+          "twin-engine design"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -11048,10 +14066,34 @@
   },
   {
     "key": "Boeing 777",
-    "altNames": ["B777"],
-    "tags": ["Airliner", "Passenger", "Cargo", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Transport", "Airliner"],
+    "altNames": [
+      "Boeing 777",
+      "B777"
+    ],
+    "tags": [
+      "Airliner",
+      "Passenger",
+      "Cargo",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/C9HcVyj/g-dhma-central-airlines-boeing-777-f-Planespotters-Net-1660970-293b854f19-o.jpg",
+      "https://i.ibb.co/cyDQKM1/hz-ak72-saudi-arabian-airlines-boeing-777-ffg-Planespotters-Net-1504085-9b2f899343-o.jpg",
+      "https://i.ibb.co/74h4kfh/n714sa-southern-air-boeing-777-fzb-Planespotters-Net-1353296-c61edfc5e2-o.jpg",
+      "https://i.ibb.co/x6yV3qQ/su-gdp-egyptair-boeing-777-36ner-Planespotters-Net-1458339-8289329509-o.jpg",
+      "https://i.ibb.co/5xRMkPk/a6-env-emirates-boeing-777-31her-Planespotters-Net-1440384-aeca2822e7-o.jpg",
+      "https://i.ibb.co/fHDqvPM/ap-bgj-pia-pakistan-international-airlines-boeing-777-240er-Planespotters-Net-1310460-a7e904a942-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/74h4kfh/n714sa-southern-air-boeing-777-fzb-Planespotters-Net-1353296-c61edfc5e2-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Airliner"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11123,7 +14165,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["twin-engine", "long-range airliner"]
+        "distinctiveFeatures": [
+          "twin-engine",
+          "long-range airliner"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -11142,10 +14187,32 @@
   },
   {
     "key": "Boeing 787",
-    "altNames": ["B787"],
-    "tags": ["Airliner", "Passenger", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport", "Airliner"],
+    "altNames": [
+      "Boeing 787",
+      "B787"
+    ],
+    "tags": [
+      "Airliner",
+      "Passenger",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/6yXLgm8/vt-anc-air-india-boeing-787-8-dreamliner-Planespotters-Net-1618453-960ae79132-o.jpg",
+      "https://i.ibb.co/tmvRgqd/vt-ane-air-india-boeing-787-8-dreamliner-Planespotters-Net-997175-76a466b9ad-o.jpg",
+      "https://i.ibb.co/17Trjvm/cc-bgz-latam-airlines-chile-boeing-787-9-dreamliner-Planespotters-Net-1565586-14b7e3cfea-o.jpg",
+      "https://i.ibb.co/CWxxNSf/hs-tqd-thai-airways-boeing-787-8-dreamliner-Planespotters-Net-553433-e4ef026b17-o.jpg",
+      "https://i.ibb.co/3Mb9vzb/hz-ar12-saudi-arabian-airlines-boeing-787-9-dreamliner-Planespotters-Net-1664305-309ab6d5f7-o.jpg",
+      "https://i.ibb.co/kJtQH9K/ja850j-zipair-tokyo-boeing-787-8-dreamliner-Planespotters-Net-1414597-9010813b5d-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/kJtQH9K/ja850j-zipair-tokyo-boeing-787-8-dreamliner-Planespotters-Net-1414597-9010813b5d-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Airliner"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11217,7 +14284,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["composite materials", "fuel efficiency"]
+        "distinctiveFeatures": [
+          "composite materials",
+          "fuel efficiency"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -11236,10 +14306,31 @@
   },
   {
     "key": "Cessna 500 Citation",
-    "altNames": ["Cessna 500", "Citation"],
-    "tags": ["Business Jet", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Business Jet"],
+    "altNames": [
+      "Cessna 500 Citation",
+      "Cessna 500",
+      "Citation"
+    ],
+    "tags": [
+      "Business Jet",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/x8Fw44g/oe-gzk-jetalliance-cessna-500-citation-Planespotters-Net-1596692-189d0cdc0f-o.jpg",
+      "https://i.ibb.co/3WYMLkB/vh-xbp-private-cessna-550b-citation-bravo-Planespotters-Net-1586153-786edc90d1-o.jpg",
+      "https://i.ibb.co/ccjFNYc/hb-vjp-private-cessna-550-citation-ii-Planespotters-Net-1461887-3d94db6e04-o.jpg",
+      "https://i.ibb.co/RjW7G3V/n41gt-private-cessna-501-citation-isp-Planespotters-Net-1394215-9bc0589a2e-o.jpg",
+      "https://i.ibb.co/Xzwwr1S/n56pb-private-cessna-501-citation-isp-Planespotters-Net-1657142-9de6cf8e18-o.jpg",
+      "https://i.ibb.co/Sm9h9QP/n444ea-private-cessna-550b-citation-bravo-Planespotters-Net-1382447-5b87f7fc6e-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/Sm9h9QP/n444ea-private-cessna-550b-citation-bravo-Planespotters-Net-1382447-5b87f7fc6e-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Business Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11311,7 +14402,10 @@
       },
       "fuselage": {
         "shape": "sleek",
-        "distinctiveFeatures": ["T-tail", "spacious cabin"]
+        "distinctiveFeatures": [
+          "T-tail",
+          "spacious cabin"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -11330,10 +14424,29 @@
   },
   {
     "key": "Dassault Falcon 50",
-    "altNames": [""],
-    "tags": ["Business Jet", "France"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Business Jet"],
+    "altNames": [
+      "Dassault Falcon 50"
+    ],
+    "tags": [
+      "Business Jet",
+      "France"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/mygNnSk/n67mt-private-dassault-falcon-50ex-Planespotters-Net-1386932-799a22213a-o.jpg",
+      "https://i.ibb.co/smsZfwj/n90hc-private-dassault-falcon-50-Planespotters-Net-645167-0de3c68f18-o.jpg",
+      "https://i.ibb.co/jg78J5Z/36-marine-nationale-french-navy-dassault-falcon-50-Planespotters-Net-1185860-b478e7221b-o.jpg",
+      "https://i.ibb.co/TDQk7YW/78-marine-nationale-french-navy-dassault-falcon-50-Planespotters-Net-1244546-3502a38009-o.jpg",
+      "https://i.ibb.co/gtTRtpP/17403-fora-area-portuguesa-portuguese-air-force-dassault-falcon-50-Planespotters-Net-1335487-78f3183.jpg",
+      "https://i.ibb.co/gRhSRh0/n27ga-private-dassault-falcon-50-Planespotters-Net-1597631-31b36bb133-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/gRhSRh0/n27ga-private-dassault-falcon-50-Planespotters-Net-1597631-31b36bb133-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Business Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11405,7 +14518,11 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["tri-jet configuration", "luxurious cabin"]
+        "distinctiveFeatures": [
+          "tri-jet configuration",
+          "luxurious cabin",
+          "Tail-mounted engine"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -11424,10 +14541,29 @@
   },
   {
     "key": "Gulf Stream",
-    "altNames": [""],
-    "tags": ["Business Jet", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Business Jet"],
+    "altNames": [
+      "Gulf Stream"
+    ],
+    "tags": [
+      "Business Jet",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/2cS3wPb/b-655s-zyb-lily-jet-gulfstream-g650-g-vi-Planespotters-Net-1511895-8c42701875-o.jpg",
+      "https://i.ibb.co/99BCLbY/n271dv-executive-jet-management-gulfstream-g650er-g-vi-Planespotters-Net-1451712-20281b5b31-o.jpg",
+      "https://i.ibb.co/k97NT0G/n475cb-private-gulfstream-g600-g-vii-Planespotters-Net-1652381-9530a07d41-o.jpg",
+      "https://i.ibb.co/RPkvFDw/vh-crq-private-gulfstream-v-g-v-Planespotters-Net-435309-872ffe2c6c-o.jpg",
+      "https://i.ibb.co/F3DknKV/06-0500-united-states-air-force-gulfstream-c-37b-g-v-sp-g550-Planespotters-Net-1666614-a86833b279-o.jpg",
+      "https://i.ibb.co/zRk8YXP/102005-swedish-air-force-gulfstream-g550-g-v-sp-Planespotters-Net-1400595-b6e674c69a-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/RPkvFDw/vh-crq-private-gulfstream-v-g-v-Planespotters-Net-435309-872ffe2c6c-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Business Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11499,7 +14635,10 @@
       },
       "fuselage": {
         "shape": "long and streamlined",
-        "distinctiveFeatures": ["spacious cabin", "high cruising speed"]
+        "distinctiveFeatures": [
+          "spacious cabin",
+          "high cruising speed"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -11518,10 +14657,29 @@
   },
   {
     "key": "Hawker 800",
-    "altNames": [""],
-    "tags": ["Business Jet", "UK"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Business Jet"],
+    "altNames": [
+      "Hawker 800"
+    ],
+    "tags": [
+      "Business Jet",
+      "UK"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/PM3qMSw/hs-emg-private-raytheon-hawker-800-Planespotters-Net-1320781-31556fc364-o.jpg",
+      "https://i.ibb.co/Qdz7RvR/i-toph-topjet-executive-srl-raytheon-hawker-850xp-Planespotters-Net-1345824-31d79d2a6d-o.jpg",
+      "https://i.ibb.co/HzLfnqL/ly-dsk-aurela-raytheon-hawker-850xp-Planespotters-Net-1395304-d9cb3f13ef-o.jpg",
+      "https://i.ibb.co/7JswrfD/n488am-private-raytheon-hawker-800xp-Planespotters-Net-1620947-297b39c7e6-o.jpg",
+      "https://i.ibb.co/GJC6h0g/tc-she-private-raytheon-hawker-850xp-Planespotters-Net-1520332-855ee3c056-o.jpg",
+      "https://i.ibb.co/stsmWTf/vt-faf-private-raytheon-hawker-800xp-Planespotters-Net-1159114-c6ec330422-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/7JswrfD/n488am-private-raytheon-hawker-800xp-Planespotters-Net-1620947-297b39c7e6-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Business Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11593,7 +14751,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["spacious cabin", "comfortable interior"]
+        "distinctiveFeatures": [
+          "spacious cabin",
+          "comfortable interior"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -11612,10 +14773,30 @@
   },
   {
     "key": "Lear Jet",
-    "altNames": [""],
-    "tags": ["Business Jet", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Business Jet"],
+    "altNames": [
+      "Lear Jet"
+    ],
+    "tags": [
+      "Business Jet",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/4Wr7Mbq/n2022l-learjet-learjet-45-Planespotters-Net-1260936-82b604308f-o.jpg",
+      "https://i.ibb.co/gPZxBGr/oe-ged-private-learjet-45-Planespotters-Net-1659656-dc6be6196c-o.jpg",
+      "https://i.ibb.co/V3TSXRt/d-cita-fai-rent-a-jet-learjet-60-Planespotters-Net-1652567-116c3f93c4-o.jpg",
+      "https://i.ibb.co/vDMspJt/es-pvn-panaviatic-learjet-60-Planespotters-Net-1646452-aaf2138079-o.jpg",
+      "https://i.ibb.co/xfhYvHp/m-abrb-ryanair-holdings-group-learjet-45-Planespotters-Net-1655186-da8031c55a-o.jpg",
+      "https://i.ibb.co/WxZdpqR/n461lj-learjet-learjet-75-Planespotters-Net-606459-60904f5410-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/V3TSXRt/d-cita-fai-rent-a-jet-learjet-60-Planespotters-Net-1652567-116c3f93c4-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Business Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11687,7 +14868,10 @@
       },
       "fuselage": {
         "shape": "sleek",
-        "distinctiveFeatures": ["compact", "high-speed performance"]
+        "distinctiveFeatures": [
+          "compact",
+          "high-speed performance"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -11706,10 +14890,32 @@
   },
   {
     "key": "Challenger",
-    "altNames": ["Bombardier Aerospace"],
-    "tags": ["Regional Jet", "Passenger", "Canada"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Transport", "Regional Jet"],
+    "altNames": [
+      "Challenger"
+    ],
+    "tags": [
+      "Regional Jet",
+      "Passenger",
+      "Canada"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/7RdStLL/cs-chb-netjets-europe-bombardier-challenger-350-bd-100-1a10-Planespotters-Net-1668116-3a81ddeddb-o.jpg",
+      "https://i.ibb.co/RQjwbLk/d-bpmi-private-bombardier-challenger-350-bd-100-1a10-Planespotters-Net-1664652-fd817e1027-o.jpg",
+      "https://i.ibb.co/xHmfLdx/ew-301pj-belarus-government-bombardier-challenger-850-cl-600-2b19-Planespotters-Net-742479-cb9f722f8.jpg",
+      "https://i.ibb.co/Xb4Knmj/n717as-airshare-bombardier-challenger-350-bd-100-1a10-Planespotters-Net-1660383-17ac9d924f-o.jpg",
+      "https://i.ibb.co/RvZ4VCK/n746qs-netjets-aviation-bombardier-challenger-350-bd-100-1a10-Planespotters-Net-1654705-21c16a5443-o.jpg",
+      "https://i.ibb.co/cTCqQP9/b-16888-private-bombardier-challenger-605-cl-600-2b16-Planespotters-Net-1656505-3235150a51-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/xHmfLdx/ew-301pj-belarus-government-bombardier-challenger-850-cl-600-2b19-Planespotters-Net-742479-cb9f722f8.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Regional Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11781,7 +14987,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["spacious cabin", "streamlined fuselage"]
+        "distinctiveFeatures": [
+          "spacious cabin",
+          "streamlined fuselage"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -11800,10 +15009,32 @@
   },
   {
     "key": "CRJ-100",
-    "altNames": ["CRJ"],
-    "tags": ["Regional Jet", "Passenger", "Canada"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport", "Regional Jet"],
+    "altNames": [
+      "CRJ-100",
+      "CRJ"
+    ],
+    "tags": [
+      "Regional Jet",
+      "Passenger",
+      "Canada"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/cLh69PT/n924cn-contour-aviation-bombardier-crj-200lr-cl-600-2b19-Planespotters-Net-1649664-8f33853799-o.jpg",
+      "https://i.ibb.co/KDBSpZw/up-c8502-government-of-kazakhstan-bombardier-crj-200er-cl-600-2b19-Planespotters-Net-1657166-2d15d78.jpg",
+      "https://i.ibb.co/nrRHrr9/9h-dom-airx-charter-bombardier-challenger-850-cl-600-2b19-Planespotters-Net-1663879-d7cdd1c455-o.jpg",
+      "https://i.ibb.co/zhb9R2v/ec-nlm-iberia-regional-bombardier-crj-200er-cl-600-2b19-Planespotters-Net-1647861-adda27cc79-o.jpg",
+      "https://i.ibb.co/4sgnRVK/f-gptd-air-littoral-bombardier-crj-100er-cl-600-2b19-Planespotters-Net-1654188-b49920de1b-o.jpg",
+      "https://i.ibb.co/4TyZ2WP/n467aw-united-express-bombardier-crj-200lr-cl-600-2b19-Planespotters-Net-1637519-7df470c715-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/nrRHrr9/9h-dom-airx-charter-bombardier-challenger-850-cl-600-2b19-Planespotters-Net-1663879-d7cdd1c455-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Regional Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11875,7 +15106,10 @@
       },
       "fuselage": {
         "shape": "slender",
-        "distinctiveFeatures": ["T-tail", "compact design"]
+        "distinctiveFeatures": [
+          "T-tail",
+          "compact design"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -11894,10 +15128,31 @@
   },
   {
     "key": "MD-80",
-    "altNames": [""],
-    "tags": ["Regional Jet", "Passenger", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport", "Regional Jet"],
+    "altNames": [
+      "MD-80"
+    ],
+    "tags": [
+      "Regional Jet",
+      "Passenger",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/K6Q5kjZ/ex-80003-tezjet-mcdonnell-douglas-md-83-dc-9-83-Planespotters-Net-1660524-396ad1eaec-o.jpg",
+      "https://i.ibb.co/B2QcqCw/n191aj-air-jamaica-mcdonnell-douglas-md-83-dc-9-83-Planespotters-Net-1656430-9667e3490b-o.jpg",
+      "https://i.ibb.co/rdq7S1t/se-dif-sas-scandinavian-airlines-mcdonnell-douglas-md-87-dc-9-87-Planespotters-Net-1600651-557e1dda0.jpg",
+      "https://i.ibb.co/2Wgp5Lg/sx-bsw-xl-airways-mcdonnell-douglas-md-83-dc-9-83-Planespotters-Net-1575053-e82a98073e-o.jpg",
+      "https://i.ibb.co/hLvrcSY/5n-sai-dana-air-mcdonnell-douglas-md-83-dc-9-83-Planespotters-Net-1669384-af639813b6-o.jpg",
+      "https://i.ibb.co/k3HdZBH/ex-80003-tezjet-mcdonnell-douglas-md-83-dc-9-83-Planespotters-Net-1660420-dff0fb1b5b-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/2Wgp5Lg/sx-bsw-xl-airways-mcdonnell-douglas-md-83-dc-9-83-Planespotters-Net-1575053-e82a98073e-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Regional Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -11969,7 +15224,10 @@
       },
       "fuselage": {
         "shape": "narrow-body",
-        "distinctiveFeatures": ["spacious cabin", "T-tail configuration"]
+        "distinctiveFeatures": [
+          "spacious cabin",
+          "T-tail configuration"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -11988,10 +15246,31 @@
   },
   {
     "key": "ERJ-145",
-    "altNames": [""],
-    "tags": ["Regional Jet", "Passenger", "Brazil"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport", "Regional Jet"],
+    "altNames": [
+      "ERJ-145"
+    ],
+    "tags": [
+      "Regional Jet",
+      "Passenger",
+      "Brazil"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/m4VrnpP/oe-ioi-mjet-embraer-emb-135bj-legacy-600-Planespotters-Net-1657895-6d363abd2d-o.jpg",
+      "https://i.ibb.co/tbPbR5q/yr-tro-toyo-aviation-embraer-emb-135bj-legacy-600-Planespotters-Net-1620146-06724313c2-o.jpg",
+      "https://i.ibb.co/c1xC8Rz/9h-wfc-airx-charter-embraer-emb-135bj-legacy-600-Planespotters-Net-1627811-14689c69b8-o.jpg",
+      "https://i.ibb.co/PQ4YVLv/f-grgk-hop-embraer-erj-145ep-Planespotters-Net-790081-d2ce185760-o.jpg",
+      "https://i.ibb.co/YBFv2QW/f-hesr-amelia-international-embraer-erj-145lr-Planespotters-Net-1625223-b6a65e04a6-o.jpg",
+      "https://i.ibb.co/RQMckLZ/n14153-united-express-embraer-erj-145xr-Planespotters-Net-1521901-2b87276f3a-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/c1xC8Rz/9h-wfc-airx-charter-embraer-emb-135bj-legacy-600-Planespotters-Net-1627811-14689c69b8-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Regional Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12063,7 +15342,10 @@
       },
       "fuselage": {
         "shape": "slender",
-        "distinctiveFeatures": ["compact design", "T-tail"]
+        "distinctiveFeatures": [
+          "compact design",
+          "T-tail"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -12082,10 +15364,32 @@
   },
   {
     "key": "ERJ-170",
-    "altNames": [""],
-    "tags": ["Regional Jet", "Passenger", "Brazil"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Transport", "Regional Jet"],
+    "altNames": [
+      "ERJ-170"
+    ],
+    "tags": [
+      "Regional Jet",
+      "Passenger",
+      "Brazil"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/7bpBZyY/n744db-american-eagle-embraer-erj-170su-erj-170-100-su-Planespotters-Net-1613406-3e8ee90d33-o.jpg",
+      "https://i.ibb.co/WyFCP1S/n760mq-american-eagle-embraer-erj-170std-erj-170-100-Planespotters-Net-1555282-a09a164a4b-o.jpg",
+      "https://i.ibb.co/QHmfCfz/ph-exh-klm-cityhopper-embraer-erj-175std-erj-170-200-std-Planespotters-Net-1669226-231e50b17c-o.jpg",
+      "https://i.ibb.co/fdKR1vP/sp-ldk-lot-polish-airlines-embraer-erj-170lr-erj-170-100-lr-Planespotters-Net-1185014-b118dfbb8a-o.jpg",
+      "https://i.ibb.co/dJmKNNP/n181sy-alaska-airlines-embraer-erj-175lr-erj-170-200-lr-Planespotters-Net-1669803-41b858f2a0-o.jpg",
+      "https://i.ibb.co/ySj6dDk/n651rw-american-eagle-embraer-erj-170se-erj-170-100-se-Planespotters-Net-1607102-d3b44c3f7d-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/ySj6dDk/n651rw-american-eagle-embraer-erj-170se-erj-170-100-se-Planespotters-Net-1607102-d3b44c3f7d-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Regional Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12157,7 +15461,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["spacious cabin", "modern avionics"]
+        "distinctiveFeatures": [
+          "spacious cabin",
+          "modern avionics"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -12175,11 +15482,147 @@
     }
   },
   {
+    "key": "DC-10",
+    "altNames": [
+      "McDonnell Douglas DC-10"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/qDcMTRr/n310fe-fedex-express-mcdonnell-douglas-dc-10-30f-Planespotters-Net-1643103-636b8ecc90-o.jpg",
+      "https://i.ibb.co/2qCXn5f/n353wl-world-airways-mcdonnell-douglas-dc-10-30-Planespotters-Net-1371567-2e42844117-o.jpg",
+      "https://i.ibb.co/wpD2HHH/n365fe-fedex-express-mcdonnell-douglas-md-10-10f-Planespotters-Net-421777-1be3f4e0f6-o.jpg",
+      "https://i.ibb.co/6ZFk937/n603ax-10-tanker-air-carrier-mcdonnell-douglas-dc-10-30er-Planespotters-Net-1642784-7f12b83d70-o.jpg",
+      "https://i.ibb.co/K9ztCXz/n241nw-northwest-airlines-mcdonnell-douglas-dc-10-30-Planespotters-Net-1650702-d961b23481-o.jpg",
+      "https://i.ibb.co/rZsx2hn/n308fe-fedex-express-mcdonnell-douglas-md-10-30f-Planespotters-Net-317262-11b94754a1-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/6ZFk937/n603ax-10-tanker-air-carrier-mcdonnell-douglas-dc-10-30er-Planespotters-Net-1642784-7f12b83d70-o.jpg",
+    "tags": [],
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Transport",
+      "Commercial"
+    ],
+    "generalData": [
+      {
+        "key": "Manufacturer",
+        "value": "McDonnell Douglas"
+      },
+      {
+        "key": "Country of Origin",
+        "value": "USA"
+      },
+      {
+        "key": "Similar Aircraft",
+        "value": "Lockheed L-1011 TriStar"
+      },
+      {
+        "key": "Distinctive Features",
+        "value": "Three-engine configuration, T-tail design"
+      },
+      {
+        "key": "Crew",
+        "value": "Three"
+      },
+      {
+        "key": "Role",
+        "value": "Commercial Transport"
+      },
+      {
+        "key": "Armament",
+        "value": "None"
+      },
+      {
+        "key": "Dimensions",
+        "value": "Length: 55.50 m, Wingspan: 50.40 m, Height: 17.70 m"
+      },
+      {
+        "key": "Names",
+        "value": "DC-10"
+      }
+    ],
+    "weftDescription": [
+      {
+        "key": "Wings",
+        "value": "Swept-back wing, low-mounted"
+      },
+      {
+        "key": "Engine(s)",
+        "value": "Three jet engines (two on wings, one in tail)"
+      },
+      {
+        "key": "Fuselage",
+        "value": "Wide-body fuselage"
+      },
+      {
+        "key": "Tail",
+        "value": "T-tail with engine mounted in tail fin"
+      }
+    ],
+    "I.S.A.B.E.L": {
+      "wings": {
+        "type": "fixed",
+        "placement": "low-mounted",
+        "shape": "swept-back",
+        "slant": "no slant",
+        "canards": false
+      },
+      "engine": {
+        "type": "jet",
+        "number": 3,
+        "location": "two on wings, one tail-mounted"
+      },
+      "fuselage": {
+        "shape": "wide-body",
+        "distinctiveFeatures": [
+          "T-tail",
+          "three engines",
+          "Tail-mounted Engine"
+        ]
+      },
+      "tail": {
+        "type": "T-tail",
+        "numberOfFins": 1
+      },
+      "dimensions": {
+        "length": 55.5,
+        "wingspan": 50.4,
+        "height": 17.7
+      },
+      "roleData": {
+        "primaryRole": "Commercial Transport",
+        "secondaryRole": "Cargo"
+      }
+    }
+  },
+  {
     "key": "E-3 Sentry",
-    "altNames": [""],
-    "tags": ["Military Special Mission", "AWACS", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Military Special Mission"],
+    "altNames": [
+      "E-3 Sentry"
+    ],
+    "tags": [
+      "Military Special Mission",
+      "AWACS",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/XYdXRVH/lx-n90444-luxembourg-nato-boeing-e-3a-sentry-707-320b-Planespotters-Net-1638821-bc1388b84f-o.jpg",
+      "https://i.ibb.co/vHB5ML9/lx-n90456-luxembourg-nato-boeing-e-3a-sentry-707-320b-Planespotters-Net-1631392-1d3cfd7c92-o.jpg",
+      "https://i.ibb.co/JmLH5nF/lx-n90456-luxembourg-nato-boeing-e-3a-sentry-707-320b-Planespotters-Net-1668905-72e63f221f-o.jpg",
+      "https://i.ibb.co/x5333wX/lx-n90458-luxembourg-nato-boeing-e-3a-sentry-707-320b-Planespotters-Net-285224-57b0c402bb-o.jpg",
+      "https://i.ibb.co/k0rgh9Y/82-0006-united-states-air-force-boeing-e-3c-sentry-707-320b-Planespotters-Net-1598346-c20183ffe4-o.jpg",
+      "https://i.ibb.co/jLZyHgX/905-fuerza-area-de-chile-chilean-air-force-boeing-e-3d-sentry-aew1-707-320b-Planespotters-Net-159727.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/XYdXRVH/lx-n90444-luxembourg-nato-boeing-e-3a-sentry-707-320b-Planespotters-Net-1638821-bc1388b84f-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Military Special Mission"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12251,7 +15694,9 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["rotating radar dome on top"]
+        "distinctiveFeatures": [
+          "rotating radar dome on top"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -12270,10 +15715,34 @@
   },
   {
     "key": "E-2 Hawkeye",
-    "altNames": ["E-2", "Hawkeye"],
-    "tags": ["Military Special Mission", "AWACS", "USA", "Carrier-Based"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Military Special Mission"],
+    "altNames": [
+      "E-2 Hawkeye",
+      "E-2",
+      "Hawkeye"
+    ],
+    "tags": [
+      "Military Special Mission",
+      "AWACS",
+      "USA",
+      "Carrier-Based"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Military Special Mission"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12345,7 +15814,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["radar dome on top", "twin tail fins"]
+        "distinctiveFeatures": [
+          "radar dome on top",
+          "twin tail fins"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -12364,10 +15836,33 @@
   },
   {
     "key": "KC-135 Stratotanker",
-    "altNames": ["KC-135", "Stratotanker"],
-    "tags": ["Military Special Mission", "Tanker", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Military Special Mission"],
+    "altNames": [
+      "KC-135 Stratotanker",
+      "KC-135",
+      "Stratotanker"
+    ],
+    "tags": [
+      "Military Special Mission",
+      "Tanker",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/zJCX75q/58-0054-united-states-air-force-boeing-kc-135t-stratotanker-717-148-Planespotters-Net-909875-5d9701c.jpg",
+      "https://i.ibb.co/yV89R78/58-0072-united-states-air-force-boeing-kc-135t-stratotanker-717-148-Planespotters-Net-1669691-89d095.jpg",
+      "https://i.ibb.co/25T8pCZ/59-1474-united-states-air-force-boeing-kc-135t-stratotanker-717-148-Planespotters-Net-1668592-2d48ff.jpg",
+      "https://i.ibb.co/19jYnmz/62-3499-united-states-air-force-boeing-kc-135r-stratotanker-717-148-Planespotters-Net-1440523-e410b6.jpg",
+      "https://i.ibb.co/Sv1TxF9/63-7992-united-states-air-force-boeing-kc-135r-stratotanker-717-148-Planespotters-Net-1650493-7b136b.jpg",
+      "https://i.ibb.co/tp7mNYd/63-8008-united-states-air-force-boeing-kc-135r-stratotanker-717-148-Planespotters-Net-1274095-72cfa7.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/zJCX75q/58-0054-united-states-air-force-boeing-kc-135t-stratotanker-717-148-Planespotters-Net-909875-5d9701c.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Military Special Mission"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12439,7 +15934,9 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["refueling boom under fuselage"]
+        "distinctiveFeatures": [
+          "refueling boom under fuselage"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -12458,10 +15955,32 @@
   },
   {
     "key": "KC-10 Extender",
-    "altNames": ["KC-10"],
-    "tags": ["Military Special Mission", "Tanker", "USA"],
-    "hltag": [],
-    "accat": ["Fixed-Wing", "Military Special Mission"],
+    "altNames": [
+      "KC-10 Extender",
+      "KC-10"
+    ],
+    "tags": [
+      "Military Special Mission",
+      "Tanker",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Military Special Mission"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12533,7 +16052,10 @@
       },
       "fuselage": {
         "shape": "wide-body",
-        "distinctiveFeatures": ["aerial refueling boom", "tail-mounted engine"]
+        "distinctiveFeatures": [
+          "aerial refueling boom",
+          "tail-mounted engine"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -12552,10 +16074,32 @@
   },
   {
     "key": "T-38 Talon",
-    "altNames": ["T-38", "Talon"],
-    "tags": ["Trainer Aircraft", "Supersonic", "USA"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Trainer"],
+    "altNames": [
+      "T-38 Talon",
+      "T-38",
+      "Talon"
+    ],
+    "tags": [
+      "Trainer Aircraft",
+      "Supersonic",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Trainer"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12627,7 +16171,10 @@
       },
       "fuselage": {
         "shape": "slender",
-        "distinctiveFeatures": ["tandem cockpit", "high-speed training design"]
+        "distinctiveFeatures": [
+          "tandem cockpit",
+          "high-speed training design"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -12646,10 +16193,34 @@
   },
   {
     "key": "L-39 Albatross",
-    "altNames": ["L-39", "Albatross"],
-    "tags": ["Trainer Aircraft", "Light Attack", "Czech Republic"],
-    "hltag": ["devtest"],
-    "accat": ["Fixed-Wing", "Trainer", "Light Attack"],
+    "altNames": [
+      "L-39 Albatross",
+      "L-39",
+      "Albatross"
+    ],
+    "tags": [
+      "Trainer Aircraft",
+      "Light Attack",
+      "Czech Republic"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Trainer",
+      "Light Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12721,7 +16292,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["tandem seating", "light attack capability"]
+        "distinctiveFeatures": [
+          "tandem seating",
+          "light attack capability"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -12740,10 +16314,31 @@
   },
   {
     "key": "CM-170 Magister",
-    "altNames": ["CM-170", "Magister"],
-    "tags": ["Trainer Aircraft", "France"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Trainer"],
+    "altNames": [
+      "CM-170 Magister",
+      "CM-170",
+      "Magister"
+    ],
+    "tags": [
+      "Trainer Aircraft",
+      "France"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Trainer"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12815,7 +16410,10 @@
       },
       "fuselage": {
         "shape": "slim",
-        "distinctiveFeatures": ["canard configuration", "twin-engine jet"]
+        "distinctiveFeatures": [
+          "canard configuration",
+          "twin-engine jet"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -12834,10 +16432,31 @@
   },
   {
     "key": "MB-339AN",
-    "altNames": [""],
-    "tags": ["Trainer Aircraft", "Light Attack", "Italy"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Trainer", "Light Attack"],
+    "altNames": [
+      "MB-339AN"
+    ],
+    "tags": [
+      "Trainer Aircraft",
+      "Light Attack",
+      "Italy"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Trainer",
+      "Light Attack"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -12909,7 +16528,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["tandem seating", "trainer/attack configuration"]
+        "distinctiveFeatures": [
+          "tandem seating",
+          "trainer/attack configuration"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -12928,10 +16550,29 @@
   },
   {
     "key": "PC-7",
-    "altNames": [""],
-    "tags": ["Trainer Aircraft", "Switzerland"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Trainer"],
+    "altNames": [
+      "PC-7"
+    ],
+    "tags": [
+      "Trainer Aircraft",
+      "Switzerland"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Trainer"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13003,7 +16644,10 @@
       },
       "fuselage": {
         "shape": "slim",
-        "distinctiveFeatures": ["tandem seating", "trainer/light attack"]
+        "distinctiveFeatures": [
+          "tandem seating",
+          "trainer/light attack"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -13022,10 +16666,33 @@
   },
   {
     "key": "MV-22 Osprey",
-    "altNames": ["MV-22", "Osprey", "V-22"],
-    "tags": ["Tiltrotor", "Multirole", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Tiltrotor", "Multirole"],
+    "altNames": [
+      "MV-22 Osprey",
+      "MV-22",
+      "Osprey",
+      "V-22"
+    ],
+    "tags": [
+      "Tiltrotor",
+      "Multirole",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/brjtPB8/168695-united-states-marine-corps-bell-boeing-mv-22b-osprey-Planespotters-Net-1524828-2cc62c7e54-o.jpg",
+      "https://i.ibb.co/4JKgxR5/169440-united-states-navy-bell-boeing-cmv-22b-osprey-Planespotters-Net-1651709-75c224233a-o.jpg",
+      "https://i.ibb.co/TR7VHz0/12-0066-united-states-air-force-bell-boeing-cv-22b-osprey-Planespotters-Net-1428786-4cdf8f33ef-o.jpg",
+      "https://i.ibb.co/SrPCJGn/166386-united-states-marine-corps-bell-boeing-mv-22b-osprey-Planespotters-Net-1588685-ce4e1514a0-o.jpg",
+      "https://i.ibb.co/4Kz2fkS/168228-united-states-marine-corps-bell-boeing-mv-22b-osprey-Planespotters-Net-1233472-360662084b-o.jpg",
+      "https://i.ibb.co/mHZhs05/168621-united-states-marine-corps-bell-boeing-mv-22b-osprey-Planespotters-Net-1645510-03321e3c3d-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/TR7VHz0/12-0066-united-states-air-force-bell-boeing-cv-22b-osprey-Planespotters-Net-1428786-4cdf8f33ef-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Tiltrotor",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13097,7 +16764,10 @@
       },
       "fuselage": {
         "shape": "boxy",
-        "distinctiveFeatures": ["tiltrotor design", "large cabin"]
+        "distinctiveFeatures": [
+          "tiltrotor design",
+          "large cabin"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -13117,10 +16787,33 @@
   },
   {
     "key": "V-282 Valor",
-    "altNames": ["V-282", "Valor"],
-    "tags": ["Tiltrotor", "Multirole", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Tiltrotor", "Multirole"],
+    "altNames": [
+      "V-282 Valor",
+      "V-282",
+      "Valor"
+    ],
+    "tags": [
+      "Tiltrotor",
+      "Multirole",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Tiltrotor",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13192,7 +16885,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["tiltrotor design", "high-mounted rotors"]
+        "distinctiveFeatures": [
+          "tiltrotor design",
+          "high-mounted rotors"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -13211,10 +16907,31 @@
   },
   {
     "key": "AW 609",
-    "altNames": ["AW 609"],
-    "tags": ["Tiltrotor", "Multirole", "Italy"],
-    "hltag": ["devtest"],
-    "accat": ["Tiltrotor", "Multirole"],
+    "altNames": [
+      "AW 609"
+    ],
+    "tags": [
+      "Tiltrotor",
+      "Multirole",
+      "Italy"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Tiltrotor",
+      "Multirole"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13286,7 +17003,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["tiltrotor design", "VTOL capabilities"]
+        "distinctiveFeatures": [
+          "tiltrotor design",
+          "VTOL capabilities"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -13305,10 +17025,32 @@
   },
   {
     "key": "NASA X-24",
-    "altNames": ["X-24"],
-    "tags": ["Experimental Aircraft", "Lifting Body", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Experimental", "Prototype"],
+    "altNames": [
+      "NASA X-24",
+      "X-24"
+    ],
+    "tags": [
+      "Experimental Aircraft",
+      "Lifting Body",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Experimental",
+      "Prototype"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13380,7 +17122,10 @@
       },
       "fuselage": {
         "shape": "lifting body",
-        "distinctiveFeatures": ["lifting body design", "no wings"]
+        "distinctiveFeatures": [
+          "lifting body design",
+          "no wings"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -13399,10 +17144,31 @@
   },
   {
     "key": "M2-F3",
-    "altNames": ["M2-F3"],
-    "tags": ["Experimental Aircraft", "Lifting Body", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Experimental", "Lifting Body"],
+    "altNames": [
+      "M2-F3"
+    ],
+    "tags": [
+      "Experimental Aircraft",
+      "Lifting Body",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Experimental",
+      "Lifting Body"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13474,7 +17240,10 @@
       },
       "fuselage": {
         "shape": "lifting body",
-        "distinctiveFeatures": ["twin vertical stabilizers", "lifting body design"]
+        "distinctiveFeatures": [
+          "twin vertical stabilizers",
+          "lifting body design"
+        ]
       },
       "tail": {
         "type": "twin",
@@ -13493,10 +17262,32 @@
   },
   {
     "key": "Grumman X-29",
-    "altNames": ["X-29"],
-    "tags": ["Experimental Aircraft", "Forward-Swept Wings", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Experimental", "Prototype"],
+    "altNames": [
+      "Grumman X-29",
+      "X-29"
+    ],
+    "tags": [
+      "Experimental Aircraft",
+      "Forward-Swept Wings",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Experimental",
+      "Prototype"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13568,7 +17359,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["forward-swept wings", "canards"]
+        "distinctiveFeatures": [
+          "forward-swept wings",
+          "canards"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -13587,10 +17381,32 @@
   },
   {
     "key": "Boeing X-48",
-    "altNames": ["X-48"],
-    "tags": ["Experimental Aircraft", "Blended-Wing Body", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Experimental", "Prototype"],
+    "altNames": [
+      "Boeing X-48",
+      "X-48"
+    ],
+    "tags": [
+      "Experimental Aircraft",
+      "Blended-Wing Body",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Experimental",
+      "Prototype"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13662,7 +17478,9 @@
       },
       "fuselage": {
         "shape": "blended wing body",
-        "distinctiveFeatures": ["blended wing body"]
+        "distinctiveFeatures": [
+          "blended wing body"
+        ]
       },
       "tail": {
         "type": "none",
@@ -13681,10 +17499,32 @@
   },
   {
     "key": "Bell X-5",
-    "altNames": ["X-5"],
-    "tags": ["Experimental Aircraft", "Variable-Sweep Wings", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Experimental", "Prototype"],
+    "altNames": [
+      "Bell X-5",
+      "X-5"
+    ],
+    "tags": [
+      "Experimental Aircraft",
+      "Variable-Sweep Wings",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Experimental",
+      "Prototype"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13756,7 +17596,9 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["variable-sweep wings"]
+        "distinctiveFeatures": [
+          "variable-sweep wings"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -13775,10 +17617,32 @@
   },
   {
     "key": "Bell XV-3",
-    "altNames": ["XV-3"],
-    "tags": ["Experimental Aircraft", "Tiltrotor", "USA"],
-    "hltag": ["devtest"],
-    "accat": ["Experimental", "Prototype"],
+    "altNames": [
+      "Bell XV-3",
+      "XV-3"
+    ],
+    "tags": [
+      "Experimental Aircraft",
+      "Tiltrotor",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "devtest",
+      "hide"
+    ],
+    "accat": [
+      "Experimental",
+      "Prototype"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13850,7 +17714,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["tiltrotor design", "VTOL capabilities"]
+        "distinctiveFeatures": [
+          "tiltrotor design",
+          "VTOL capabilities"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -13869,10 +17736,32 @@
   },
   {
     "key": "Beechcraft Baron",
-    "altNames": ["Beech Baron"],
-    "tags": ["Civil Utility", "Propeller", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "Beechcraft Baron",
+      "Beech Baron"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/CbNnLB0/ja5808-civil-aviation-college-hawker-beechcraft-baron-g58-Planespotters-Net-1587315-a1bfb84d06-o.jpg",
+      "https://i.ibb.co/n3qCg19/n2ww-private-beechcraft-58-baron-Planespotters-Net-1655753-896adb9484-o.jpg",
+      "https://i.ibb.co/xfLKhwF/n500tl-private-beechcraft-58-baron-Planespotters-Net-1649386-2a13221b06-o.jpg",
+      "https://i.ibb.co/xXYDwTg/n783pt-private-beechcraft-95-b55-baron-Planespotters-Net-1507034-b279851686-o.jpg",
+      "https://i.ibb.co/1Md4L0H/hb-gmm-humanitarian-pilots-initiative-hpi-beechcraft-58-baron-Planespotters-Net-1605205-0fa8a3e856-o.jpg",
+      "https://i.ibb.co/QcQ7Qvd/ja5314-private-beechcraft-58-baron-Planespotters-Net-1142171-04586c8c1b-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/xfLKhwF/n500tl-private-beechcraft-58-baron-Planespotters-Net-1649386-2a13221b06-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -13944,7 +17833,10 @@
       },
       "fuselage": {
         "shape": "spacious",
-        "distinctiveFeatures": ["light transport", "business use"]
+        "distinctiveFeatures": [
+          "light transport",
+          "business use"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -13963,10 +17855,31 @@
   },
   {
     "key": "Beechcraft Bonanza",
-    "altNames": ["Beech Bonanza"],
-    "tags": ["Civil Utility", "Propeller", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "Beechcraft Bonanza",
+      "Beech Bonanza"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/bHqMSzW/n97wb-private-beechcraft-v35-bonanza-Planespotters-Net-1650698-2d312c8daa-o.jpg",
+      "https://i.ibb.co/T1cbxr7/n4572a-private-beechcraft-v35b-bonanza-Planespotters-Net-1666325-2ce611246c-o.jpg",
+      "https://i.ibb.co/TtK0xJ8/n6696w-private-beechcraft-v35b-bonanza-Planespotters-Net-1667519-5f98f61802-o.jpg",
+      "https://i.ibb.co/WWMK3Kc/n9620y-private-beechcraft-p35-bonanza-Planespotters-Net-1513613-2bb436cb0a-o.jpg",
+      "https://i.ibb.co/fFbKh48/hb-egs-private-beechcraft-d35-bonanza-Planespotters-Net-1606951-103c148731-o.jpg",
+      "https://i.ibb.co/8gXTh8q/n6f-private-beechcraft-f35-bonanza-Planespotters-Net-949240-520fe72daa-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/fFbKh48/hb-egs-private-beechcraft-d35-bonanza-Planespotters-Net-1606951-103c148731-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14038,7 +17951,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["single-engine", "V-tail in some models"]
+        "distinctiveFeatures": [
+          "single-engine",
+          "V-tail in some models"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -14057,10 +17973,33 @@
   },
   {
     "key": "Cessna 172 Skyhawk",
-    "altNames": ["Cessna 172", "Skyhawk"],
-    "tags": ["Civil Utility", "Propeller", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "Cessna 172 Skyhawk",
+      "Cessna 172",
+      "Skyhawk"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/hZH7M4M/n19805-private-cessna-172m-skyhawk-Planespotters-Net-1669916-59d50c15cc-o.jpg",
+      "https://i.ibb.co/kJQvx45/n54661-private-cessna-172m-skyhawk-Planespotters-Net-1158248-653e92cee0-o.jpg",
+      "https://i.ibb.co/WGH8hkK/d-ecma-eisenbahner-sportverein-innsbruck-cessna-172m-skyhawk-Planespotters-Net-1612481-088aeb0e0b-o.jpg",
+      "https://i.ibb.co/4t884vh/d-ettu-private-cessna-172s-skyhawk-sp-Planespotters-Net-1667143-c7075efa6f-o.jpg",
+      "https://i.ibb.co/whJ5BxH/g-rarb-private-cessna-172n-Planespotters-Net-1620122-92fcb47d8e-o.jpg",
+      "https://i.ibb.co/CKVXh9w/n5138r-private-cessna-172m-skyhawk-Planespotters-Net-1668160-76852dadf6-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/whJ5BxH/g-rarb-private-cessna-172n-Planespotters-Net-1620122-92fcb47d8e-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14132,7 +18071,10 @@
       },
       "fuselage": {
         "shape": "small",
-        "distinctiveFeatures": ["high-wing", "single-engine"]
+        "distinctiveFeatures": [
+          "high-wing",
+          "single-engine"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -14151,10 +18093,30 @@
   },
   {
     "key": "Cessna 310",
-    "altNames": [""],
-    "tags": ["Civil Utility", "Propeller", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "Cessna 310"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/r2ScwzF/pr-fgg-private-cessna-310r-Planespotters-Net-290411-41c73562cd-o.jpg",
+      "https://i.ibb.co/mRWFKtN/pr-fgg-private-cessna-310r-Planespotters-Net-313951-fb4c9bb203-o.jpg",
+      "https://i.ibb.co/F8L8DX0/5r-mlj-aeromarine-cessna-310-Planespotters-Net-086709-8664bea4df-o.jpg",
+      "https://i.ibb.co/BsyVR3x/d-ibmm-untitled-cessna-310-q-Planespotters-Net-1172286-a7737b1254-o.jpg",
+      "https://i.ibb.co/cQ81V5Y/pr-fgg-private-cessna-310-Planespotters-Net-290839-ce42722561-o.jpg",
+      "https://i.ibb.co/34nmnFG/pr-fgg-private-cessna-310r-Planespotters-Net-286936-cf5cfc2623-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/cQ81V5Y/pr-fgg-private-cessna-310-Planespotters-Net-290839-ce42722561-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14226,7 +18188,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin-engine", "utility design"]
+        "distinctiveFeatures": [
+          "twin-engine",
+          "utility design"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -14246,10 +18211,33 @@
   },
   {
     "key": "Cessna 421 Golden Eagle",
-    "altNames": ["Cessna 421", "Golden Eagle"],
-    "tags": ["Civil Utility", "Propeller", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "Cessna 421 Golden Eagle",
+      "Cessna 421",
+      "Golden Eagle"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/41F2V1v/d-izzy-alpha-air-germany-cessna-421c-golden-eagle-Planespotters-Net-725653-00c88ffc2e-o.jpg",
+      "https://i.ibb.co/0sdpQ56/ec-ihy-geo-data-air-cessna-421c-golden-eagle-Planespotters-Net-1646663-2603dbb7a2-o.jpg",
+      "https://i.ibb.co/n7TK2Kd/g-svip-private-cessna-421b-golden-eagle-ii-Planespotters-Net-326171-a16acbfbc6-o.jpg",
+      "https://i.ibb.co/mCysFQM/n207fm-show-low-construction-cessna-421c-golden-eagle-Planespotters-Net-644749-91cf1ea324-o.jpg",
+      "https://i.ibb.co/1X6p1NN/n421cj-private-cessna-421c-golden-eagle-Planespotters-Net-1652509-1d2b13d850-o.jpg",
+      "https://i.ibb.co/4VWSBLT/sp-fnv-private-cessna-421c-golden-eagle-iii-Planespotters-Net-787719-22905ac4bc-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/mCysFQM/n207fm-show-low-construction-cessna-421c-golden-eagle-Planespotters-Net-644749-91cf1ea324-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14321,7 +18309,10 @@
       },
       "fuselage": {
         "shape": "spacious",
-        "distinctiveFeatures": ["high-wing design", "spacious cabin"]
+        "distinctiveFeatures": [
+          "high-wing design",
+          "spacious cabin"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -14341,10 +18332,32 @@
   },
   {
     "key": "Beechcraft King Air",
-    "altNames": ["Beech King Air"],
-    "tags": ["Transport", "Propeller", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "Beechcraft King Air",
+      "Beech King Air"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/xHKSm7k/b-9790-china-jiutian-aviation-school-beechcraft-c90-king-air-Planespotters-Net-1596479-f2f34cd8d2-o.jpg",
+      "https://i.ibb.co/T01GxRz/f-hnav-direction-gnrale-de-laviation-civile-dgac-beechcraft-king-air-b200gt-Planespotters-Net-118675.jpg",
+      "https://i.ibb.co/Lrd0Kms/n95vb-private-beechcraft-king-air-c90gti-Planespotters-Net-1416583-229be9e1a8-o.jpg",
+      "https://i.ibb.co/VS0WD83/sp-tpu-polish-air-navigation-services-agency-pansa-beechcraft-b300-king-air-350-Planespotters-Net-16.jpg",
+      "https://i.ibb.co/WyWKrPY/7t-wrp-algerian-air-force-beechcraft-350-super-king-air-Planespotters-Net-1249645-5016373db0-o.jpg",
+      "https://i.ibb.co/N9DNLFv/76-0168-united-states-air-force-beech-c-12c-huron-Planespotters-Net-1120987-385f4df17d-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/N9DNLFv/76-0168-united-states-air-force-beech-c-12c-huron-Planespotters-Net-1120987-385f4df17d-o.jpg",
+    "tags": [
+      "Transport",
+      "Propeller",
+      "USA"
+    ],
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14416,7 +18429,10 @@
       },
       "fuselage": {
         "shape": "slim",
-        "distinctiveFeatures": ["twin-turboprop", "utility design"]
+        "distinctiveFeatures": [
+          "twin-turboprop",
+          "utility design"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -14436,10 +18452,30 @@
   },
   {
     "key": "Dash 8",
-    "altNames": [""],
-    "tags": ["Transport", "Regional", "Canada"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport"],
+    "altNames": [
+      "Dash 8"
+    ],
+    "tags": [
+      "Transport",
+      "Regional",
+      "Canada"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/ypd8ryD/g-ecod-flybe-bombardier-dhc-8-402q-dash-8-Planespotters-Net-996865-41a6dd3610-o.jpg",
+      "https://i.ibb.co/s6xjc5G/g-kkev-flybe-bombardier-dhc-8-402q-dash-8-Planespotters-Net-313119-2441b51601-o.jpg",
+      "https://i.ibb.co/H2PsJNP/lx-lqc-luxair-bombardier-dhc-8-402q-dash-8-Planespotters-Net-1655003-cd1c08f867-o.jpg",
+      "https://i.ibb.co/4JSs10d/5n-bkx-arik-air-bombardier-dhc-8-402q-dash-8-Planespotters-Net-549409-2abd548506-o.jpg",
+      "https://i.ibb.co/SV3Z2ZN/c-fhnf-air-tanzania-bombardier-dhc-8-402q-dash-8-Planespotters-Net-718934-23918481ca-o.jpg",
+      "https://i.ibb.co/bdmWb9D/c-ggfj-air-canada-express-bombardier-dhc-8-402q-dash-8-Planespotters-Net-1656164-c4775893d3-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/s6xjc5G/g-kkev-flybe-bombardier-dhc-8-402q-dash-8-Planespotters-Net-313119-2441b51601-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14511,7 +18547,10 @@
       },
       "fuselage": {
         "shape": "wide",
-        "distinctiveFeatures": ["regional airliner", "high-wing"]
+        "distinctiveFeatures": [
+          "regional airliner",
+          "high-wing"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -14531,10 +18570,32 @@
   },
   {
     "key": "Mooney M-22 Mustang",
-    "altNames": ["Mooney Mustang", "M-22"],
-    "tags": ["Civil Utility", "Propeller", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "Mooney M-22 Mustang",
+      "Mooney Mustang",
+      "M-22"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/hyJxjdX/g-bjhb-private-mooney-m20j-Planespotters-Net-693441-b7e4f7113d-o.jpg",
+      "https://i.ibb.co/thKLFpq/hb-dio-private-mooney-m20r-ovation-Planespotters-Net-1667468-4336489dbb-o.jpg",
+      "https://i.ibb.co/Y34jXFK/hb-dvy-private-mooney-m22-mustang-Planespotters-Net-344539-26d0fe18a1-o.jpg",
+      "https://i.ibb.co/yBmMnh2/n231bd-untitled-mooney-m20k-Planespotters-Net-762368-e3af474ff8-o.jpg",
+      "https://i.ibb.co/SnNsHc5/n772df-private-mooney-m20j-Planespotters-Net-1555598-e05890d09f-o.jpg",
+      "https://i.ibb.co/Hpcdf7q/n808wm-private-mooney-m20r-ovation-Planespotters-Net-1652516-b9b27acb0a-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/Y34jXFK/hb-dvy-private-mooney-m22-mustang-Planespotters-Net-344539-26d0fe18a1-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14606,7 +18667,10 @@
       },
       "fuselage": {
         "shape": "compact",
-        "distinctiveFeatures": ["light utility", "T-tail configuration"]
+        "distinctiveFeatures": [
+          "light utility",
+          "T-tail configuration"
+        ]
       },
       "tail": {
         "type": "T-tail",
@@ -14626,10 +18690,33 @@
   },
   {
     "key": "Piper PA-18 Cub",
-    "altNames": ["Piper Cub", "PA-18"],
-    "tags": ["Civil Utility", "Propeller", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "Piper PA-18 Cub",
+      "Piper Cub",
+      "PA-18"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/bW2ywqX/n1227n-untitled-piper-j-3c-65-cub-Planespotters-Net-1358364-492b50066e-o.jpg",
+      "https://i.ibb.co/cbgSwvn/n74996-private-piper-pa-18-150-super-cub-Planespotters-Net-1212147-b0b2b9dbe9-o.jpg",
+      "https://i.ibb.co/LZM16FD/nc55754-private-piper-j-3-cub-Planespotters-Net-1606329-2caf711cd0-o.jpg",
+      "https://i.ibb.co/sJFGJDB/oe-ape-flugsportklub-sturmvogel-wiener-neustadt-piper-pa-18-super-cub-Planespotters-Net-1658274-c547.jpg",
+      "https://i.ibb.co/D75KppB/f-ghlq-private-piper-j-3-cub-Planespotters-Net-1595709-2702322794-o.jpg",
+      "https://i.ibb.co/1vbmrj9/hb-onh-private-piper-j-3-cub-Planespotters-Net-635489-bcbdd98e19-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/sJFGJDB/oe-ape-flugsportklub-sturmvogel-wiener-neustadt-piper-pa-18-super-cub-Planespotters-Net-1658274-c547.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14701,7 +18788,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["high-wing", "light aircraft"]
+        "distinctiveFeatures": [
+          "high-wing",
+          "light aircraft"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -14720,10 +18810,33 @@
   },
   {
     "key": "Piper PA-28 Cherokee",
-    "altNames": ["Piper Cherokee", "PA-28"],
-    "tags": ["Civil Utility", "Propeller", "USA"],
-    "hltag": ["NCR", "devtest"],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "Piper PA-28 Cherokee",
+      "Piper Cherokee",
+      "PA-28"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/T43xMSS/n356va-private-piper-pa-32-301-saratoga-Planespotters-Net-1660342-956f1af3b8-o.jpg",
+      "https://i.ibb.co/NV7M0G1/oy-drz-evair-piper-pa-28-140-cherokee-b-Planespotters-Net-1667301-78a1c316ed-o.jpg",
+      "https://i.ibb.co/y5ywdMR/9h-aez-european-pilot-academy-malta-piper-pa-28-161-warrior-iii-Planespotters-Net-160860-0f7ae44490.jpg",
+      "https://i.ibb.co/Q7gd88D/g-bhze-private-piper-pa-28-181-archer-ii-Planespotters-Net-1668666-43ba6094fe-o.jpg",
+      "https://i.ibb.co/6wzhS4t/g-blfi-private-piper-pa-28-181-cherokee-archer-ii-Planespotters-Net-1669532-fce971667a-o.jpg",
+      "https://i.ibb.co/7bGF5v6/hb-pqd-flugschule-basel-piper-pa-28-181-archer-ii-Planespotters-Net-1664106-72159d8c90-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/6wzhS4t/g-blfi-private-piper-pa-28-181-cherokee-archer-ii-Planespotters-Net-1669532-fce971667a-o.jpg",
+    "hltag": [
+      "NCR",
+      "devtest"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14795,7 +18908,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["low-wing", "trainer"]
+        "distinctiveFeatures": [
+          "low-wing",
+          "trainer"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -14814,10 +18930,30 @@
   },
   {
     "key": "SR-22",
-    "altNames": [""],
-    "tags": ["Civil Utility", "Propeller", "USA"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "SR-22"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "USA"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/Vqsq13m/n611es-private-cirrus-sr22-gts-Planespotters-Net-1643691-321dd5fa6b-o.jpg",
+      "https://i.ibb.co/x1XzcTz/n5147y-private-cirrus-sr22-g2-Planespotters-Net-1668153-6e7fb5605e-o.jpg",
+      "https://i.ibb.co/RNTYT3p/sp-wiw-private-cirrus-sr-22-t-gts-g6-carbon-Planespotters-Net-1627544-32b0730ebe-o.jpg",
+      "https://i.ibb.co/mt6KZbB/d-escd-private-cirrus-sr22-Planespotters-Net-1467388-727c552c5d-o.jpg",
+      "https://i.ibb.co/L5PfyFp/d-etml-private-cirrus-sr22-gts-Planespotters-Net-1586247-c633e1c2e5-o.jpg",
+      "https://i.ibb.co/5LsQmbJ/f-hkco-airbus-flight-academy-cirrus-sr22-Planespotters-Net-1665107-11c7e67af8-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/RNTYT3p/sp-wiw-private-cirrus-sr-22-t-gts-g6-carbon-Planespotters-Net-1627544-32b0730ebe-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14889,7 +19025,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["sleek design", "modern avionics"]
+        "distinctiveFeatures": [
+          "sleek design",
+          "modern avionics"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -14908,10 +19047,31 @@
   },
   {
     "key": "Saab 340",
-    "altNames": [""],
-    "tags": ["Regional", "Passenger", "Sweden"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport", "Regional Jet"],
+    "altNames": [
+      "Saab 340"
+    ],
+    "tags": [
+      "Regional",
+      "Passenger",
+      "Sweden"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/M5Zt3V3/vh-vez-link-airways-saab-340b-Planespotters-Net-1649957-5d7e6e9a8d-o.jpg",
+      "https://i.ibb.co/y5JQFpZ/vh-zpa-rex-airlines-saab-340b-Planespotters-Net-1650394-54e8ec8ec8-o.jpg",
+      "https://i.ibb.co/51FqS9S/zk-fxb-air-new-zealand-link-saab-340a-Planespotters-Net-1657265-e1fb04f7c8-o.jpg",
+      "https://i.ibb.co/SR3kTBt/zk-nlg-air-nelson-saab-340a-Planespotters-Net-1659124-579753a273-o.jpg",
+      "https://i.ibb.co/4ZF7S72/ja953a-japan-coast-guard-saab-340b-sar-200-Planespotters-Net-1658385-aff139b3f2-o.jpg",
+      "https://i.ibb.co/LRM341B/vh-kdk-rex-airlines-saab-fairchild-340a-Planespotters-Net-023656-18088f04e8-o.jpg"
+    ],
+    "primaryimgurl": "https://ibb.co/JxPwJLn",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Regional Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -14983,7 +19143,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["twin-engine", "regional transport"]
+        "distinctiveFeatures": [
+          "twin-engine",
+          "regional transport"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -15002,10 +19165,32 @@
   },
   {
     "key": "ATR-72",
-    "altNames": [""],
-    "tags": ["Regional", "Passenger", "France", "Italy"],
-    "hltag": ["NCR"],
-    "accat": ["Fixed-Wing", "Transport", "Regional Jet"],
+    "altNames": [
+      "ATR-72"
+    ],
+    "tags": [
+      "Regional",
+      "Passenger",
+      "France",
+      "Italy"
+    ],
+    "imageurls": [
+      "https://i.ibb.co/ZY39SXp/f-wweg-fiji-link-atr-72-600-72-212a-Planespotters-Net-1667959-fee6eb6f6c-o.jpg",
+      "https://i.ibb.co/7RkWVZW/ok-gfs-czech-airlines-csa-atr-72-500-72-212a-Planespotters-Net-1082588-98fee71d62-o.jpg",
+      "https://i.ibb.co/4JJ8b1K/oy-yan-express-airways-atr-72-500-72-212a-Planespotters-Net-627119-4589570adb-o.jpg",
+      "https://i.ibb.co/3dzxsRS/zk-mve-air-new-zealand-link-atr-72-600-72-212a-Planespotters-Net-521393-ffe4a59c37-o.jpg",
+      "https://i.ibb.co/rMbX0Yp/ec-lrh-iberia-regional-atr-72-600-72-212a-Planespotters-Net-1669584-a01a6f70e8-o.jpg",
+      "https://i.ibb.co/LttcfhZ/ec-mmm-binter-canarias-atr-72-600-72-212a-Planespotters-Net-711527-634b28c619-o.jpg"
+    ],
+    "primaryimgurl": "https://i.ibb.co/7RkWVZW/ok-gfs-czech-airlines-csa-atr-72-500-72-212a-Planespotters-Net-1082588-98fee71d62-o.jpg",
+    "hltag": [
+      "NCR"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Transport",
+      "Regional Jet"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -15077,7 +19262,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["high-wing", "twin-engine"]
+        "distinctiveFeatures": [
+          "high-wing",
+          "twin-engine"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -15096,10 +19284,32 @@
   },
   {
     "key": "An-2 Colt",
-    "altNames": ["An-2", "Colt"],
-    "tags": ["Civil Utility", "Propeller", "Russia/USSR"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Utility"],
+    "altNames": [
+      "An-2 Colt",
+      "An-2",
+      "Colt"
+    ],
+    "tags": [
+      "Civil Utility",
+      "Propeller",
+      "Russia/USSR"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -15171,7 +19381,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["biplane", "STOL"]
+        "distinctiveFeatures": [
+          "biplane",
+          "STOL"
+        ]
       },
       "tail": {
         "type": "conventional",
@@ -15190,10 +19403,33 @@
   },
   {
     "key": "O-2 Skymaster",
-    "altNames": ["O-2", "Skymaster"],
-    "tags": ["Reconnaissance", "Utility", "USA"],
-    "hltag": [""],
-    "accat": ["Fixed-Wing", "Recon", "Utility"],
+    "altNames": [
+      "O-2 Skymaster",
+      "O-2",
+      "Skymaster"
+    ],
+    "tags": [
+      "Reconnaissance",
+      "Utility",
+      "USA"
+    ],
+    "imageurls": [
+      "exampleurl#1.com",
+      "exampleurl#2.com",
+      "exampleurl#3.com",
+      "exampleurl#4.com",
+      "exampleurl#5.com",
+      "exampleurl#6.com"
+    ],
+    "primaryimgurl": "exampleurl#1.com",
+    "hltag": [
+      "hide"
+    ],
+    "accat": [
+      "Fixed-Wing",
+      "Recon",
+      "Utility"
+    ],
     "generalData": [
       {
         "key": "Manufacturer",
@@ -15265,7 +19501,10 @@
       },
       "fuselage": {
         "shape": "streamlined",
-        "distinctiveFeatures": ["push-pull engine", "twin boom"]
+        "distinctiveFeatures": [
+          "push-pull engine",
+          "twin boom"
+        ]
       },
       "tail": {
         "type": "twin-boom",


### PR DESCRIPTION
**Purpose:**
This update introduces several changes to the aircraft metadata, focusing on the addition of image references and tagging refinements to improve data consistency and user interaction.

**Key Changes:**

**1. Addition of imageurls Array and primaryimgurl:**

- For each aircraft entry, a new imageurls array has been added, which includes 6 placeholder URLs such as "exampleurl#1.com", "exampleurl#2.com", and so on. These URLs will be manually replaced with actual image links stored in the imgBB in the future.

- URLs for the "NCR" tag were added. 

- A primaryimgurl field has also been introduced, which references the primary image ( "best" array) that will be used to represent the aircraft.

**2. Tagging Enhancements – Addition of the "hide" Tag:**

- For aircraft entries that do not contain the "NCR" tag in the hltag array, the "hide" tag has been added. This allows for selective visibility or filtering of certain aircraft in relevant systems.

**3. Maintained Data Integrity:**

- All other existing fields, including tags, hltag, accat, and other key-value pairs, have been retained with their original wording and structure. No data has been removed or altered outside of the aforementioned updates.

**Expected Benefits:**

- Improved Visual Representation: The addition of imageurls and primaryimgurl fields facilitates the linking of public image URLs, improving the display and representation of aircraft.

- Data Filtering: The "hide" tag allows systems to better filter and manage the visibility of aircraft data that do not meet certain criteria, such as the absence of the "NCR" tag.

- Scalability: The update is future-proof and ready for the actual image URLs to be inserted when the images become available in imgBB .

**Notes for Developers:**

- Ensure that systems integrating with this metadata can handle and process the newly added imageurls array and primaryimgurl.

- Systems should be updated to recognize the "hide" tag, especially when filtering aircraft that are not tagged with "NCR".

This update aligns the metadata with future scalability requirements while preserving the integrity of the existing data.